### PR TITLE
fix: update device list from main queue

### DIFF
--- a/MiniSim/MenuBar/MiniSim.swift
+++ b/MiniSim/MenuBar/MiniSim.swift
@@ -95,8 +95,10 @@ class MiniSim {
                         }
                         menuItem.target = self
                         
-                        self.devices.append(device)
-                        self.menu.insertItem(menuItem, at: 3)
+                        DispatchQueue.main.async {
+                            self.devices.append(device)
+                            self.menu.insertItem(menuItem, at: 3)
+                        }
                     }
                 case .failure(let error):
                     print(error)
@@ -120,8 +122,10 @@ class MiniSim {
                         
                         menuItem.target = self
                         
-                        self.devices.append(device)
-                        self.menu.insertItem(menuItem, at: 1)
+                        DispatchQueue.main.async {
+                            self.devices.append(device)
+                            self.menu.insertItem(menuItem, at: 1)
+                        }
                     }
                 case .failure(let error):
                     print(error)


### PR DESCRIPTION
This PR fixes updating UI elements on the background task queue and sets it to main queue.