### PR TITLE
feat: copy device name and UUID on iOS

### DIFF
--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		766BD2382981628C0042261B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 766BD2372981628C0042261B /* Assets.xcassets */; };
 		766BD23B2981628C0042261B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 766BD23A2981628C0042261B /* Preview Assets.xcassets */; };
 		76730BB9298C1DF80019C680 /* DeviceMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76730BB8298C1DF80019C680 /* DeviceMenuItem.swift */; };
+		76D305722994155C005C373B /* IOSSubMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D305712994155C005C373B /* IOSSubMenuItem.swift */; };
 		76F04A11298A5AE000BF9CA3 /* ADB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F04A10298A5AE000BF9CA3 /* ADB.swift */; };
 		76F04A14298A62CF00BF9CA3 /* ShellOut in Frameworks */ = {isa = PBXBuildFile; productRef = 76F04A13298A62CF00BF9CA3 /* ShellOut */; };
 		76F2A912299033EA002D4EF6 /* DeviceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2A911299033EA002D4EF6 /* DeviceError.swift */; };
@@ -59,6 +60,7 @@
 		766BD23A2981628C0042261B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		766BD23C2981628C0042261B /* MiniSim.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MiniSim.entitlements; sourceTree = "<group>"; };
 		76730BB8298C1DF80019C680 /* DeviceMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceMenuItem.swift; sourceTree = "<group>"; };
+		76D305712994155C005C373B /* IOSSubMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSSubMenuItem.swift; sourceTree = "<group>"; };
 		76F04A10298A5AE000BF9CA3 /* ADB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADB.swift; sourceTree = "<group>"; };
 		76F2A911299033EA002D4EF6 /* DeviceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceError.swift; sourceTree = "<group>"; };
 		76F2A913299050F9002D4EF6 /* UserDefaults+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Configuration.swift"; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				762CF1E22981DE5400099999 /* Model */,
 				7645D4C12982CA9600019227 /* AppDelegate.swift */,
 				76F2A91829924242002D4EF6 /* AndroidSubMenuItem.swift */,
+				76D305712994155C005C373B /* IOSSubMenuItem.swift */,
 				7630B25D2984339100D8B57D /* MenuSections.swift */,
 				76730BB8298C1DF80019C680 /* DeviceMenuItem.swift */,
 				7630B27B2987207200D8B57D /* Menu.swift */,
@@ -277,6 +280,7 @@
 				7645D4C22982CA9600019227 /* AppDelegate.swift in Sources */,
 				76F04A11298A5AE000BF9CA3 /* ADB.swift in Sources */,
 				76730BB9298C1DF80019C680 /* DeviceMenuItem.swift in Sources */,
+				76D305722994155C005C373B /* IOSSubMenuItem.swift in Sources */,
 				7645D4C42982CB2B00019227 /* MiniSim.swift in Sources */,
 				76F2A912299033EA002D4EF6 /* DeviceError.swift in Sources */,
 				7630B2682985C4CF00D8B57D /* About.swift in Sources */,

--- a/MiniSim/IOSSubMenuItem.swift
+++ b/MiniSim/IOSSubMenuItem.swift
@@ -1,0 +1,41 @@
+//
+//  iOSSubMenuItem.swift
+//  MiniSim
+//
+//  Created by Oskar Kwaśniewski on 08/02/2023.
+//
+
+import Cocoa
+
+enum IOSSubMenuItem: Int, CaseIterable {
+    
+    case copyName = 100
+    case copyUDID = 101
+    
+    var menuItem: NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = rawValue
+        item.image = image
+        item.title = title
+        item.toolTip = title
+        return item
+    }
+    
+    var title: String {
+        switch self {
+        case .copyName:
+            return NSLocalizedString("Copy name", comment: "")
+        case .copyUDID:
+            return NSLocalizedString("Copy UDID", comment: "")
+        }
+    }
+    
+    var image: NSImage? {
+        switch self {
+        case .copyName:
+            return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Copy name")
+        case .copyUDID:
+            return NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy UDID")
+        }
+    }
+}

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -71,6 +71,20 @@ class Menu: NSMenu {
         }
     }
     
+    @objc private func IOSSubMenuClick(_ sender: NSMenuItem) {
+        guard let device = getDeviceByName(name: sender.parent?.title ?? "") else {
+            return
+        }
+        if let tag = IOSSubMenuItem(rawValue: sender.tag) {
+            switch tag {
+            case .copyName:
+                NSPasteboard.general.copyToPasteboard(text: device.name)
+            case .copyUDID:
+                NSPasteboard.general.copyToPasteboard(text: device.uuid ?? "")
+            }
+        }
+    }
+    
     @objc private func deviceItemClick(_ sender: NSMenuItem) {
         guard let device = getDeviceByName(name: sender.title) else {
             return
@@ -132,6 +146,7 @@ class Menu: NSMenu {
             )
             menuItem.target = self
             menuItem.keyEquivalentModifierMask = [.command]
+            menuItem.submenu = populateIOSSubMenu()
             
             if !items.contains(where: { $0.title == device.name }) {
                 DispatchQueue.main.async {
@@ -146,6 +161,16 @@ class Menu: NSMenu {
         AndroidSubMenuItem.allCases.map({$0.menuItem}).forEach { item in
             item.target = self
             item.action = #selector(androidSubMenuClick)
+            subMenu.addItem(item)
+        }
+        return subMenu
+    }
+    
+    private func populateIOSSubMenu() -> NSMenu {
+        let subMenu = NSMenu()
+        IOSSubMenuItem.allCases.map({$0.menuItem}).forEach { item in
+            item.target = self
+            item.action = #selector(IOSSubMenuClick)
             subMenu.addItem(item)
         }
         return subMenu


### PR DESCRIPTION
This PR adds option to copy device name and UUID for iOS simulators.

<img width="470" alt="CleanShot 2023-02-08 at 18 42 43@2x" src="https://user-images.githubusercontent.com/52801365/217609696-b597a3a4-15d7-4fc0-8375-ddfcc5b34bfb.png">
