### PR TITLE
feat: split devices to two arrays, add ANDROID_HOME fallback

### DIFF
--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -457,7 +457,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.oskarkwasniewski.MiniSim;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -493,7 +493,7 @@
 					"@loader_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.oskarkwasniewski.MiniSim;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -10,10 +10,11 @@ import KeyboardShortcuts
 
 class Menu: NSMenu {
     var deviceService: DeviceServiceProtocol!
-    var devices: [Device] = [] {
-        didSet {
-            buildMenu()
-        }
+    var iosDevices: [Device] = [] {
+        didSet { populateIOSDevices() }
+    }
+    var androidDevices: [Device] = [] {
+        didSet { populateAndroidDevices() }
     }
     
     required init(coder: NSCoder) {
@@ -27,7 +28,14 @@ class Menu: NSMenu {
     }
     
     private func getDeviceByName(name: String) -> Device? {
-        devices.first { $0.name == name }
+        var device: Device?
+        
+        device = iosDevices.first { $0.name == name }
+        
+        if device == nil {
+            device = androidDevices.first { $0.name == name }
+        }
+        return device
     }
     
     @objc private func androidSubMenuClick(_ sender: NSMenuItem) {
@@ -111,14 +119,7 @@ class Menu: NSMenu {
         return Character(UnicodeScalar(0x0030+index)!).lowercased()
     }
     
-    private func buildMenu() {
-        if (self.items.count == devices.count) {
-            return
-        }
-        
-        let androidDevices = devices.filter({ $0.isAndroid })
-        let iOSDevices = devices.filter({ !$0.isAndroid })
-        
+    private func populateAndroidDevices() {
         Array(androidDevices.enumerated()).forEach { index, device in
             let menuItem = NSMenuItem(
                 title: device.name,
@@ -132,12 +133,14 @@ class Menu: NSMenu {
             
             if !items.contains(where: { $0.title == device.name }) {
                 DispatchQueue.main.async {
-                    self.insertItem(menuItem, at: iOSDevices.count + 3)
+                    self.insertItem(menuItem, at: self.iosDevices.count + 3)
                 }
             }
         }
-        
-        Array(iOSDevices.enumerated()).forEach { index, device in
+    }
+    
+    private func populateIOSDevices() {
+        Array(iosDevices.enumerated()).forEach { index, device in
             let menuItem = NSMenuItem(
                 title: device.name,
                 action: #selector(deviceItemClick),

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -94,7 +94,7 @@ class MiniSim: NSObject {
         self.deviceService.getAndroidDevices { result in
             switch result {
             case .success(let devices):
-                self.menu.devices.append(contentsOf: devices)
+                self.menu.androidDevices.append(contentsOf: devices)
             case .failure(let error):
                 NSAlert.showError(message: error.localizedDescription)
             }
@@ -105,7 +105,7 @@ class MiniSim: NSObject {
         deviceService.getIOSDevices { result in
             switch result {
             case .success(let devices):
-                self.menu.devices.append(contentsOf: devices)
+                self.menu.iosDevices.append(contentsOf: devices)
             case .failure(let error):
                 NSAlert.showError(message: error.localizedDescription)
             }

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -27,6 +27,12 @@ final class ADB: NSObject, ADBProtocol {
         case bash_profile = "~/.bash_profile"
     }
     
+    private enum Paths: String {
+        case home = "/Android/sdk"
+        case emulator = "/emulator/emulator"
+        case adb = "/platform-tools/adb"
+    }
+    
     private static func getSourceFileScript(file: String) -> String {
         return """
                 file=\(file)
@@ -51,7 +57,13 @@ final class ADB: NSObject, ADBProtocol {
         } catch {
             // Ignore errors they can be thrown if user has incorrect setup
         }
+        
         if androidHome.isEmpty {
+            let libraryDirectory = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)
+            if let path = libraryDirectory.first {
+                return path + Paths.home.rawValue
+            }
+            
             throw DeviceError.AndroidStudioError
         }
         return androidHome
@@ -63,7 +75,7 @@ final class ADB: NSObject, ADBProtocol {
         }
         
         do {
-            let adbPath = try getAndroidHome() + "/platform-tools/adb"
+            let adbPath = try getAndroidHome() + Paths.adb.rawValue
             UserDefaults.standard.adbPath = adbPath
             return adbPath
         }
@@ -78,7 +90,7 @@ final class ADB: NSObject, ADBProtocol {
         }
         
         do {
-            let emulatorPath = try getAndroidHome() + "/emulator/emulator"
+            let emulatorPath = try getAndroidHome() + Paths.emulator.rawValue
             UserDefaults.standard.emulatorPath = emulatorPath
             return emulatorPath
         }

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,23 +6,19 @@
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
     <item>
-      <title>0.2.0</title>
+      <title>0.2.1</title>
       <description>
       <![CDATA[ <ul>
-        <li>Added support for copying device name and UDID for iOS.</li>
-        <li>Added support for copying device name and adb id for Android.</li>
-        <li>Added support for toggling a11y on Android devices.</li>
-        <li>Changed way of getting developer tools paths to sourcing config files.</li>
-        <li>Added auto update experience</li>
+        <li>Added default fallback for users having problems with ANDROID_HOME variable not being set.</li>
       </ul> ]]>
       </description>
-      <pubDate>2023-02-09</pubDate>
-      <releaseNotesLink>https://github.com/okwasniewski/MiniSim/releases/tag/0.2.0</releaseNotesLink>
+      <pubDate>2023-02-11</pubDate>
+      <releaseNotesLink>https://github.com/okwasniewski/MiniSim/releases/tag/v0.2.1</releaseNotesLink>
       <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
       <enclosure
-        url="https://github.com/okwasniewski/MiniSim/releases/download/0.2.0/MiniSim.app.zip"
-        sparkle:version="1"
-        sparkle:shortVersionString="0.2.0"
+        url="https://github.com/okwasniewski/MiniSim/releases/download/v0.2.1/MiniSim.app.zip"
+        sparkle:version="2"
+        sparkle:shortVersionString="0.2.1"
         length="0"
         type="application/octet-stream"
       />


### PR DESCRIPTION
This PR addresses issues about `ANDROID_HOME` path not being set for some users. Now it fallbacks to default path where Android studio installs the sdk tools