### PR TITLE
feat: focus devices using accessibility API

### DIFF
--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		766BD2382981628C0042261B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 766BD2372981628C0042261B /* Assets.xcassets */; };
 		766BD23B2981628C0042261B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 766BD23A2981628C0042261B /* Preview Assets.xcassets */; };
 		76730BB9298C1DF80019C680 /* DeviceMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76730BB8298C1DF80019C680 /* DeviceMenuItem.swift */; };
+		767C761F29B26ED3009B9AEC /* AccessibilityElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767C761E29B26ED3009B9AEC /* AccessibilityElement.swift */; };
 		768F8EC829954C8A00DFBCDB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 768F8EC729954C8A00DFBCDB /* Sparkle */; };
 		76D305722994155C005C373B /* IOSSubMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D305712994155C005C373B /* IOSSubMenuItem.swift */; };
 		76F04A11298A5AE000BF9CA3 /* ADB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F04A10298A5AE000BF9CA3 /* ADB.swift */; };
@@ -61,6 +62,7 @@
 		766BD23A2981628C0042261B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		766BD23C2981628C0042261B /* MiniSim.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MiniSim.entitlements; sourceTree = "<group>"; };
 		76730BB8298C1DF80019C680 /* DeviceMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceMenuItem.swift; sourceTree = "<group>"; };
+		767C761E29B26ED3009B9AEC /* AccessibilityElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityElement.swift; sourceTree = "<group>"; };
 		768F8ECC2995575B00DFBCDB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		76D305712994155C005C373B /* IOSSubMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSSubMenuItem.swift; sourceTree = "<group>"; };
 		76F04A10298A5AE000BF9CA3 /* ADB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADB.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				7645D4BC2982800D00019227 /* Service */,
 				762CF1E22981DE5400099999 /* Model */,
 				7645D4C12982CA9600019227 /* AppDelegate.swift */,
+				767C761E29B26ED3009B9AEC /* AccessibilityElement.swift */,
 				7630B27B2987207200D8B57D /* Menu.swift */,
 				7645D4C32982CB2B00019227 /* MiniSim.swift */,
 				7645D5002982E6FA00019227 /* main.swift */,
@@ -298,6 +301,7 @@
 				7645D4C42982CB2B00019227 /* MiniSim.swift in Sources */,
 				76F2A912299033EA002D4EF6 /* DeviceError.swift in Sources */,
 				7630B2682985C4CF00D8B57D /* About.swift in Sources */,
+				767C761F29B26ED3009B9AEC /* AccessibilityElement.swift in Sources */,
 				7630B2732986C68000D8B57D /* PaneIdentifier.swift in Sources */,
 				7630B2662985C44A00D8B57D /* Preferences.swift in Sources */,
 				7625140B2992B46D0060A225 /* Pasteboard+utils.swift in Sources */,

--- a/MiniSim/AccessibilityElement.swift
+++ b/MiniSim/AccessibilityElement.swift
@@ -1,0 +1,60 @@
+//
+//  AccessibilityElement.swift
+//  MiniSim
+//
+//  Created by Oskar Kwaśniewski on 03/03/2023.
+//
+
+import AppKit
+import ShellOut
+
+class AccessibilityElement {
+    private let underlyingElement: AXUIElement
+    
+    required init(_ axUIElement: AXUIElement) {
+        self.underlyingElement = axUIElement
+    }
+    
+    @discardableResult func performAction(key: String) -> AXError {
+        AXUIElementPerformAction(underlyingElement, key as CFString)
+    }
+    
+    func attribute<T>(key: NSAccessibility.Attribute, type: T.Type) -> T? {
+        var value: AnyObject?
+        let result = AXUIElementCopyAttributeValue(underlyingElement, key as CFString, &value)
+        
+        guard
+            result == .success,
+            let typedValue = value as? T
+        else {
+            return nil
+        }
+        
+        return typedValue
+    }
+    
+    func setAttribute(key: String, value: CFTypeRef) {
+        AXUIElementSetAttributeValue(underlyingElement, key as CFString, value);
+    }
+    
+    static func forceFocus(pid: pid_t) {
+        DispatchQueue.global(qos: .background).async {
+            let script = """
+                    osascript -e 'tell application "System Events"
+                        set frontmost of every process whose unix id is \(pid) to true
+                    end tell'
+                    """
+            _ = try? shellOut(to: script)
+        }
+    }
+    
+    static func allWindowsForPID(_ pid: pid_t) -> [AccessibilityElement] {
+        let app = AccessibilityElement(AXUIElementCreateApplication(pid))
+        let windows = app.attribute(key: .windows, type: [AXUIElement].self)
+        guard let windows else {
+            return []
+        }
+        
+        return windows.map({AccessibilityElement($0)})
+    }
+}

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -129,6 +129,11 @@ class Menu: NSMenu {
         guard let device = getDeviceByName(name: sender.title) else { return }
         guard let tag = DeviceMenuItem(rawValue: sender.tag) else { return }
         
+        if device.booted {
+            deviceService.focusDevice(device)
+            return
+        }
+        
         Task {
             do {
                 switch tag {


### PR DESCRIPTION
Goal of this PR is to use accessibility API and focus emulators instead of trying to open new.

Accessibility API didn't work properly for focusing android emulators so I came up with an workaround, and I'm focusing them using AppleScript. 