### PR TITLE
feat: Add delete iOS simulator sub-menu item

### DIFF
--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -125,6 +125,17 @@ class Menu: NSMenu {
                     NSPasteboard.general.copyToPasteboard(text: deviceID)
                     showNotification(title: "Device ID copied to clipboard!", body: deviceID)
                 }
+            case .deleteSim:
+                if let deviceID = device.ID {
+                    DispatchQueue.global().async { [self] in
+                        do {
+                            try deviceService.deleteSimulator(uuid: deviceID)
+                            showNotification(title: "Simulator deleted!", body: deviceID)
+                        } catch {
+                            NSAlert.showError(message: error.localizedDescription)
+                        }
+                    }
+                }
             }
         }
     }

--- a/MiniSim/MenuItems/IOSSubMenuItem.swift
+++ b/MiniSim/MenuItems/IOSSubMenuItem.swift
@@ -11,6 +11,7 @@ enum IOSSubMenuItem: Int, CaseIterable {
     
     case copyName = 100
     case copyUDID = 101
+    case deleteSim = 102
     
     var menuItem: NSMenuItem {
         let item = NSMenuItem()
@@ -27,6 +28,8 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSLocalizedString("Copy name", comment: "")
         case .copyUDID:
             return NSLocalizedString("Copy UDID", comment: "")
+        case .deleteSim:
+            return NSLocalizedString("Delete simulator", comment: "")
         }
     }
     
@@ -36,6 +39,9 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Copy name")
         case .copyUDID:
             return NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy UDID")
+        case .deleteSim:
+            return NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete simulator")
         }
+        
     }
 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -12,6 +12,7 @@ import AppKit
 protocol DeviceServiceProtocol {
     func launchDevice(uuid: String) throws
     func getIOSDevices() throws -> [Device]
+    func deleteSimulator(uuid: String) throws
     
     func launchDevice(name: String, additionalArguments: [String]) throws
     func toggleA11y(device: Device) throws
@@ -129,6 +130,10 @@ extension DeviceService {
                 throw error
             }
         }
+    }
+    
+    func deleteSimulator(uuid: String) throws {
+        try shellOut(to: ProcessPaths.xcrun.rawValue, arguments: ["simctl", "delete", uuid])
     }
     
 }


### PR DESCRIPTION
This PR adds a `Delete simulator` submenu item for iOS devices, exposing a quick and easy way to de-clutter a long list of iOS devices.
<img width="481" alt="image" src="https://user-images.githubusercontent.com/16213922/225091763-1ca9e9d5-adc2-40bd-afe7-fef9c46fa02b.png">
