### PR TITLE
fix: ignore android force quitting error, truncate error description

### DIFF
--- a/MiniSim/Extensions/NSAlert+showError.swift
+++ b/MiniSim/Extensions/NSAlert+showError.swift
@@ -13,10 +13,10 @@ extension NSAlert {
         DispatchQueue.main.async {
             let alert = self.init()
             alert.alertStyle = .warning
-            var messageText = message
+            var messageText = ""
             
             if let appName = Bundle.main.appName {
-                messageText = "\(appName) - " + message
+                messageText = "\(appName) - " + String(message.prefix(300))
             }
             
             alert.messageText = messageText

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -146,7 +146,15 @@ extension DeviceService {
             return "-\($0)"
         }
         arguments.append(contentsOf: formattedArguments)
-        try shellOut(to: emulatorPath, arguments: arguments)
+        do {
+            try shellOut(to: emulatorPath, arguments: arguments)
+        } catch {
+            // Ignore force qutting emulator (CMD + Q)
+            if error.localizedDescription.contains("unexpected system image feature string") {
+                return
+            }
+            throw error
+        }
     }
     
     func getAndroidDevices() throws -> [Device] {


### PR DESCRIPTION
This PR silently catches error while force quitting the Android emulator and also truncates the description so that It doesn't cover the whole screen.

