### PR TITLE
feat: delete ios simulators

### DIFF
--- a/MiniSim/Extensions/NSAlert+showError.swift
+++ b/MiniSim/Extensions/NSAlert+showError.swift
@@ -24,4 +24,14 @@ extension NSAlert {
             alert.runModal()
         }
     }
+    
+    static func showQuestionDialog(title: String, message: String) -> Bool {
+        let alert = self.init()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
 }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -125,6 +125,17 @@ class Menu: NSMenu {
                     NSPasteboard.general.copyToPasteboard(text: deviceID)
                     showNotification(title: "Device ID copied to clipboard!", body: deviceID)
                 }
+            case .deleteSim:
+                if let deviceID = device.ID {
+                    DispatchQueue.global().async { [self] in
+                        do {
+                            try deviceService.deleteSimulator(uuid: deviceID)
+                            showNotification(title: "Simulator deleted!", body: deviceID)
+                        } catch {
+                            NSAlert.showError(message: error.localizedDescription)
+                        }
+                    }
+                }
             }
         }
     }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -126,16 +126,21 @@ class Menu: NSMenu {
                     showNotification(title: "Device ID copied to clipboard!", body: deviceID)
                 }
             case .deleteSim:
-                if let deviceID = device.ID {
-                    DispatchQueue.global().async { [self] in
-                        do {
-                            try deviceService.deleteSimulator(uuid: deviceID)
-                            showNotification(title: "Simulator deleted!", body: deviceID)
-                        } catch {
-                            NSAlert.showError(message: error.localizedDescription)
-                        }
+                guard let deviceID = device.ID else { return }
+                if !NSAlert.showQuestionDialog(title: "Are you sure?", message: "Are you sure you want to delete this Simulator?") {
+                    return
+                }
+                DispatchQueue.global().async { [self] in
+                    do {
+                        try deviceService.deleteSimulator(uuid: deviceID)
+                        showNotification(title: "Simulator deleted!", body: deviceID)
+                        getDevices()
+                    } catch {
+                        NSAlert.showError(message: error.localizedDescription)
                     }
                 }
+            default:
+                break
             }
         }
     }
@@ -175,10 +180,10 @@ class Menu: NSMenu {
         let deviceItems = items.filter { !sections.contains($0.title) }
         let iosDeviceNames = devices.filter({ !$0.isAndroid }).map { $0.name }
         let androidDeviceNames = devices.filter({ $0.isAndroid }).map { $0.name }
-
+        
         let iosDevices = deviceItems.filter { iosDeviceNames.contains($0.title) }
         let androidDevices = deviceItems.filter { androidDeviceNames.contains($0.title) }
-
+        
         assignKeyEquivalent(devices: iosDevices)
         assignKeyEquivalent(devices: androidDevices)
     }
@@ -276,10 +281,10 @@ class Menu: NSMenu {
     
     private func safeInsertItem(_ item: NSMenuItem, at index: Int) {
         guard !items.contains(where: {$0.title == item.title}), index <= items.count else {
-        return
-      }
-
-      insertItem(item, at: index)
+            return
+        }
+        
+        insertItem(item, at: index)
     }
     
     private func safeRemoveItem(_ item: NSMenuItem?) {

--- a/MiniSim/MenuItems/IOSSubMenuItem.swift
+++ b/MiniSim/MenuItems/IOSSubMenuItem.swift
@@ -11,6 +11,7 @@ enum IOSSubMenuItem: Int, CaseIterable {
     
     case copyName = 100
     case copyUDID = 101
+    case deleteSim = 102
     
     var menuItem: NSMenuItem {
         let item = NSMenuItem()
@@ -27,6 +28,8 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSLocalizedString("Copy name", comment: "")
         case .copyUDID:
             return NSLocalizedString("Copy UDID", comment: "")
+        case .deleteSim:
+            return NSLocalizedString("Delete simulator", comment: "")
         }
     }
     
@@ -36,6 +39,9 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Copy name")
         case .copyUDID:
             return NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy UDID")
+        case .deleteSim:
+            return NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete simulator")
         }
+        
     }
 }

--- a/MiniSim/MenuItems/IOSSubMenuItem.swift
+++ b/MiniSim/MenuItems/IOSSubMenuItem.swift
@@ -11,10 +11,11 @@ enum IOSSubMenuItem: Int, CaseIterable {
     
     case copyName = 100
     case copyUDID = 101
-    case deleteSim = 102
+    case separator = 102
+    case deleteSim = 103
     
     var menuItem: NSMenuItem {
-        let item = NSMenuItem()
+        let item = self == .separator ? .separator() : NSMenuItem()
         item.tag = rawValue
         item.image = image
         item.title = title
@@ -30,6 +31,8 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSLocalizedString("Copy UDID", comment: "")
         case .deleteSim:
             return NSLocalizedString("Delete simulator", comment: "")
+        default:
+            return ""
         }
     }
     
@@ -41,7 +44,8 @@ enum IOSSubMenuItem: Int, CaseIterable {
             return NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy UDID")
         case .deleteSim:
             return NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete simulator")
+        default:
+            return nil
         }
-        
     }
 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -12,6 +12,7 @@ import AppKit
 protocol DeviceServiceProtocol {
     func launchDevice(uuid: String) throws
     func getIOSDevices() throws -> [Device]
+    func deleteSimulator(uuid: String) throws
     
     func launchDevice(name: String, additionalArguments: [String]) throws
     func toggleA11y(device: Device) throws
@@ -129,6 +130,10 @@ extension DeviceService {
                 throw error
             }
         }
+    }
+    
+    func deleteSimulator(uuid: String) throws {
+        try shellOut(to: ProcessPaths.xcrun.rawValue, arguments: ["simctl", "delete", uuid])
     }
     
 }


### PR DESCRIPTION
This PR adds a Delete simulator submenu item for iOS devices, exposing a quick and easy way to declutter a long list of iOS devices. Originally created by (@RafikiTiki)


https://user-images.githubusercontent.com/52801365/225970499-2e889ea6-0cb0-4369-ab46-eeafa6d972d0.mp4

