### PR TITLE
feat: add option to create a Pixel 6 Android 13 simulator

### DIFF
--- a/MiniSim/MenuItems/MenuSections.swift
+++ b/MiniSim/MenuItems/MenuSections.swift
@@ -11,6 +11,7 @@ enum MenuSections: Int, CaseIterable {
     case iOSHeader = 100
     case separator1 = 1
     case androidHeader = 101
+    case createNewAndroidSimulator = 102
     
     case separator2 = 2
     case clearDerrivedData = 119
@@ -56,6 +57,8 @@ enum MenuSections: Int, CaseIterable {
             return NSLocalizedString("Preferences", comment: "")
         case .clearDerrivedData:
             return NSLocalizedString("Clear Xcode Derived Data", comment: "")
+        case .createNewAndroidSimulator:
+            return NSLocalizedString("Create Pixel 6 Android 13 Simulator", comment: "")
         default:
             return ""
         }

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -114,6 +114,14 @@ class MiniSim: NSObject {
                         NSAlert.showError(message: error.localizedDescription)
                     }
                 }
+            case .createNewAndroidSimulator:
+              DispatchQueue.global().async {
+                do {
+                  try ADB.installPixel6WithAndroid13()
+                } catch  {
+                  NSAlert.showError(message: error.localizedDescription)
+                }
+              }
             default:
                 break
             }
@@ -126,7 +134,8 @@ class MiniSim: NSObject {
             return
         }
         MenuSections.allCases.map({$0.menuItem}).forEach { item in
-            if item.tag >= MenuSections.clearDerrivedData.rawValue {
+            if item.tag >= MenuSections.clearDerrivedData.rawValue ||
+               item.tag == MenuSections.createNewAndroidSimulator.rawValue {
                 item.action = #selector(menuItemAction)
                 item.target = self
             } else {

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -14,6 +14,7 @@ import UserNotifications
 class MiniSim: NSObject {
     private var statusBar: NSStatusBar!
     private var menu: Menu!
+    private var deviceService: DeviceServiceProtocol!
     
     @objc let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     
@@ -25,6 +26,7 @@ class MiniSim: NSObject {
         super.init()
         statusBar = NSStatusBar()
         menu = Menu()
+        deviceService = DeviceService()
         statusItem.menu = menu
         
         settingsController.window?.delegate = self
@@ -117,7 +119,7 @@ class MiniSim: NSObject {
             case .createNewAndroidSimulator:
               DispatchQueue.global().async {
                 do {
-                  try ADB.installPixel6WithAndroid13()
+                  try self.deviceService.installPixel6WithAndroid13()
                 } catch  {
                   NSAlert.showError(message: error.localizedDescription)
                 }

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -14,7 +14,7 @@ protocol ADBProtocol {
     static func getAdbId(for deviceName: String, adbPath: String) throws -> String
     static func checkAndroidHome(path: String) throws -> Bool
     static func isAccesibilityOn(deviceId: String, adbPath: String) -> Bool
-    static func installPixel6WithAndroid13() throws
+    static func getCmdLineToolsPath() throws -> String
 }
 
 final class ADB: ADBProtocol {
@@ -47,6 +47,10 @@ final class ADB: ADBProtocol {
     
     static func getAdbPath() throws -> String {
         return try getAndroidHome() + Paths.adb.rawValue
+    }
+
+    static func getCmdLineToolsPath() throws -> String {
+        return try getAndroidHome() + Paths.cmdLineTools.rawValue
     }
     
     /**
@@ -95,10 +99,4 @@ final class ADB: ADBProtocol {
         
         return false
     }
-
-  static func installPixel6WithAndroid13() throws {
-    let androidHome = try Self.getAndroidHome()
-    try shellOut(to: "\(androidHome + Paths.cmdLineTools.rawValue)/sdkmanager", arguments: ["--install", "\"system-images;android-33;google_apis;arm64-v8a\""])
-    try shellOut(to: "echo no |  \(androidHome + Paths.cmdLineTools.rawValue)/avdmanager", arguments: ["create", "avd", "-n", "Android_13_Pixel_6", "-k", "\"system-images;android-33;google_apis;arm64-v8a\""])
-  }
 }

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -14,6 +14,7 @@ protocol ADBProtocol {
     static func getAdbId(for deviceName: String, adbPath: String) throws -> String
     static func checkAndroidHome(path: String) throws -> Bool
     static func isAccesibilityOn(deviceId: String, adbPath: String) -> Bool
+    static func installPixel6WithAndroid13() throws
 }
 
 final class ADB: ADBProtocol {
@@ -25,6 +26,7 @@ final class ADB: ADBProtocol {
         case home = "/Android/sdk"
         case emulator = "/emulator/emulator"
         case adb = "/platform-tools/adb"
+        case cmdLineTools = "/cmdline-tools/latest/bin"
     }
     
     /**
@@ -93,4 +95,10 @@ final class ADB: ADBProtocol {
         
         return false
     }
+
+  static func installPixel6WithAndroid13() throws {
+    let androidHome = try Self.getAndroidHome()
+    try shellOut(to: "\(androidHome + Paths.cmdLineTools.rawValue)/sdkmanager", arguments: ["--install", "\"system-images;android-33;google_apis;arm64-v8a\""])
+    try shellOut(to: "echo no |  \(androidHome + Paths.cmdLineTools.rawValue)/avdmanager", arguments: ["create", "avd", "-n", "Android_13_Pixel_6", "-k", "\"system-images;android-33;google_apis;arm64-v8a\""])
+  }
 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -21,6 +21,7 @@ protocol DeviceServiceProtocol {
     func getAndroidDevices() throws -> [Device]
     func sendText(device: Device, text: String) throws
     static func checkAndroidSetup() throws -> String
+    func installPixel6WithAndroid13() throws
     
     func focusDevice(_ device: Device)
 }
@@ -218,4 +219,10 @@ extension DeviceService {
         
         try shellOut(to: "\(adbPath) -s \(deviceId) shell input text \"\(formattedText)\"")
     }
+
+    func installPixel6WithAndroid13() throws {
+        let cmdLineToolsPath = try ADB.getCmdLineToolsPath()
+        try shellOut(to: "\(cmdLineToolsPath)/sdkmanager", arguments: ["--install", "\"system-images;android-33;google_apis;arm64-v8a\""])
+        try shellOut(to: "echo no |  \(cmdLineToolsPath)/avdmanager", arguments: ["create", "avd", "-n", "Android_13_Pixel_6", "-k", "\"system-images;android-33;google_apis;arm64-v8a\""])
+  }
 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -223,6 +223,6 @@ extension DeviceService {
     func installPixel6WithAndroid13() throws {
         let cmdLineToolsPath = try ADB.getCmdLineToolsPath()
         try shellOut(to: "\(cmdLineToolsPath)/sdkmanager", arguments: ["--install", "\"system-images;android-33;google_apis;arm64-v8a\""])
-        try shellOut(to: "echo no |  \(cmdLineToolsPath)/avdmanager", arguments: ["create", "avd", "-n", "Android_13_Pixel_6", "-k", "\"system-images;android-33;google_apis;arm64-v8a\""])
+        try shellOut(to: "echo no |  \(cmdLineToolsPath)/avdmanager", arguments: ["create", "avd", "-n", "Android_13_Pixel_6", "-k", "\"system-images;android-33;google_apis;arm64-v8a\"", "-d", "29"])
   }
 }


### PR DESCRIPTION
It would be nice to create an Android sim directly with this tool.
I created a menu option to create a Pixel 6 with Android 13 simulator.

I'm not an Apple/iOS dev, so you can also just take this as "inspiration" :)

![image](https://github.com/okwasniewski/MiniSim/assets/5817002/483ca1ac-01fb-4794-85a1-fed8e49f0065)
