### PR TITLE
fix: fixed multiple simulator with same names and different versions

### DIFF
--- a/MiniSim/Model/Device.swift
+++ b/MiniSim/Model/Device.swift
@@ -10,6 +10,18 @@ struct Device: Hashable {
     var version: String?
     var ID: String?
     var booted: Bool = false
+    var platform: Platform
     
-    var isAndroid: Bool = false
+    var displayName: String {
+        switch platform {
+        case .ios:
+            if let version {
+                return "\(name) - (\(version))"
+            }
+            return name
+            
+        case .android:
+            return name
+        }
+    }
 }


### PR DESCRIPTION
Goal of this PR is to fix issues with multiple versions of iOS emulators. Currently MiniSim doesn't differentiate between iOS versions which causes the first version returned bym `xcrun simctl` to be displayed.

Now MiniSim will display all versions of iOS Simulators. This PR also resolves this: #53 

Before: 

<img width="404" alt="Screenshot 2023-06-10 at 10 29 56" src="https://github.com/okwasniewski/MiniSim/assets/52801365/325608d8-9468-4089-bc7c-decc0932351d">

After:

<img width="483" alt="Screenshot 2023-06-10 at 10 29 53" src="https://github.com/okwasniewski/MiniSim/assets/52801365/6a0c7731-a406-45b5-810d-561137352296">
