### PR TITLE
Adopting Swift Concurrency

### DIFF
--- a/MiniSim/AppleScript Commands/ExecuteCommand.swift
+++ b/MiniSim/AppleScript Commands/ExecuteCommand.swift
@@ -27,7 +27,9 @@ class ExecuteCommand: NSScriptCommand {
         
         if platform == .android {
             if let menuItem = AndroidSubMenuItem(rawValue: rawTag) {
-                DeviceService.handleAndroidAction(device: device, commandTag: menuItem, itemName: commandName)
+                Task {
+                    try? await DeviceService.handleAndroidAction(device: device, commandTag: menuItem, itemName: commandName)
+                }
             }
             
             return nil;
@@ -35,7 +37,9 @@ class ExecuteCommand: NSScriptCommand {
         
         
         if let menuItem = IOSSubMenuItem(rawValue: rawTag) {
-            DeviceService.handleiOSAction(device: device, commandTag: menuItem, itemName: commandName)
+            Task {
+                try? await DeviceService.handleiOSAction(device: device, commandTag: menuItem, itemName: commandName)
+            }
         }
         
         

--- a/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
+++ b/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
@@ -26,11 +26,15 @@ class LaunchDeviceCommand: NSScriptCommand {
             }
             
             if device.booted {
-                DeviceService.focusDevice(device)
+                Task {
+                    await DeviceService.focusDevice(device)
+                }
                 return nil
             }
             
-            DeviceService.launch(device: device) { _ in }
+            Task {
+                try? await DeviceService.launch(device: device)
+            }
             return nil
         } catch {
             scriptErrorNumber = NSInternalScriptError;

--- a/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
+++ b/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
@@ -30,19 +30,11 @@ class LaunchDeviceCommand: NSScriptCommand {
                 return nil
             }
             
-            DispatchQueue.global(qos: .userInitiated).async {
-                if device.platform == .android {
-                    try? DeviceService.launchDevice(name: device.name)
-                } else {
-                    try? DeviceService.launchDevice(uuid: device.ID ?? "")
-                }
-            }
-            
+            DeviceService.launch(device: device) { _ in }
             return nil
         } catch {
             scriptErrorNumber = NSInternalScriptError;
             return nil
         }
-        
     }
 }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -78,22 +78,16 @@ class Menu: NSMenu {
     
     @objc private func deviceItemClick(_ sender: NSMenuItem) {
         guard let device = getDeviceByName(name: sender.title) else { return }
-        guard let tag = DeviceMenuItem(rawValue: sender.tag) else { return }
-        
+    
         if device.booted {
             DeviceService.focusDevice(device)
             return
-        }
+        }        
         
-        do {
-            switch tag {
-            case .launchAndroid:
-                try DeviceService.launchDevice(name: device.name)
-            case .launchIOS:
-                try DeviceService.launchDevice(uuid: device.ID ?? "")
+        DeviceService.launch(device: device) { error in
+            if let error = error {
+                NSAlert.showError(message: error.localizedDescription)
             }
-        } catch {
-            NSAlert.showError(message: error.localizedDescription)
         }
     }
     

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -148,19 +148,18 @@ class MiniSim: NSObject {
                 if !shouldDelete {
                     return
                 }
-                DispatchQueue.global(qos: .userInitiated).async {
-                    do {
-                        let amountCleared = try DeviceService.clearDerivedData()
-                        UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
-                        NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
-                    } catch {
-                        NSAlert.showError(message: error.localizedDescription)
+
+                DeviceService.clearDerivedData() { amountCleared, error in
+                    guard error == nil else {
+                        NSAlert.showError(message: error?.localizedDescription ?? "Failed to clear derived  data.")
+                        return
                     }
+                    UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
+                    NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
                 }
             default:
                 break
             }
-            
         }
     }
     

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -149,13 +149,14 @@ class MiniSim: NSObject {
                     return
                 }
 
-                DeviceService.clearDerivedData() { amountCleared, error in
-                    guard error == nil else {
-                        NSAlert.showError(message: error?.localizedDescription ?? "Failed to clear derived  data.")
-                        return
+                Task {
+                    do {
+                        let amountCleared = try await DeviceService.clearDerivedData()
+                        UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
+                        NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
+                    } catch {
+                        await NSAlert.showError(message: error.localizedDescription)
                     }
-                    UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
-                    NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
                 }
             default:
                 break

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -155,6 +155,32 @@ class DeviceService: DeviceServiceProtocol {
         UNUserNotificationCenter.showNotification(title: title, body: message)
         NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
     }
+    
+    static func getAllDevices(
+        android: Bool,
+        iOS: Bool,
+        completionQueue: DispatchQueue = .main,
+        completion: @escaping ([Device], Error?) -> ()
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                var devicesArray: [Device] = []
+                if android {
+                    try devicesArray.append(contentsOf: getAndroidDevices())
+                }
+                if iOS {
+                    try devicesArray.append(contentsOf: getIOSDevices())
+                }
+                completionQueue.async {
+                    completion(devicesArray, nil)
+                }
+            } catch {
+                completionQueue.async {
+                    completion([], error)
+                }
+            }
+        }
+    }
 }
 
 // MARK: iOS Methods

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -31,6 +31,7 @@ protocol DeviceServiceProtocol {
 
 class DeviceService: DeviceServiceProtocol {
     
+    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .utility)
     private static let deviceBootedError = "Unable to boot device in current state: Booted"
     
     private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"
@@ -90,7 +91,7 @@ class DeviceService: DeviceServiceProtocol {
     }
     
     static func focusDevice(_ device: Device) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        queue.async {
             
             let runningApps = NSWorkspace.shared.runningApplications.filter({$0.activationPolicy == .regular})
             
@@ -159,7 +160,7 @@ class DeviceService: DeviceServiceProtocol {
         completionQueue: DispatchQueue = .main,
         completion: @escaping ([Device], Error?) -> ()
     ) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        queue.async {
             do {
                 var devicesArray: [Device] = []
                 if android {
@@ -299,7 +300,7 @@ extension DeviceService {
             if !NSAlert.showQuestionDialog(title: "Are you sure?", message: "Are you sure you want to delete this Simulator?") {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            queue.async {
                 do {
                     try DeviceService.deleteSimulator(uuid: deviceID)
                     DeviceService.showSuccessMessage(title: "Simulator deleted!", message: deviceID)
@@ -312,7 +313,7 @@ extension DeviceService {
             guard let command = DeviceService.getCustomCommand(platform: .ios, commandName: itemName) else {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            queue.async {
                 do {
                     try DeviceService.runCustomCommand(device, command: command)
                 } catch {

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -11,14 +11,12 @@ import AppKit
 import UserNotifications
 
 protocol DeviceServiceProtocol {
-    static func launchDevice(uuid: String) throws
     static func getIOSDevices() throws -> [Device]
     static func checkXcodeSetup() -> Bool
     static func deleteSimulator(uuid: String) throws
     static func clearDerivedData() throws -> String
     static func handleiOSAction(device: Device, commandTag: IOSSubMenuItem, itemName: String)
     
-    static func launchDevice(name: String, additionalArguments: [String]) throws
     static func toggleA11y(device: Device) throws
     static func getAndroidDevices() throws -> [Device]
     static func sendText(device: Device, text: String) throws
@@ -181,6 +179,34 @@ class DeviceService: DeviceServiceProtocol {
             }
         }
     }
+    
+    private static func launch(device: Device) throws {
+        switch device.platform {
+        case .ios:
+            try launchDevice(uuid: device.ID)
+        case .android:
+            try launchDevice(name: device.name)
+        }
+    }
+    
+    static func launch(device: Device, completionQueue: DispatchQueue = .main, completion: @escaping (Error?) -> Void) {
+        self.queue.async {
+            do {
+                try self.launch(device: device)
+                completionQueue.async {
+                    completion(nil)
+                }
+            }
+            catch {
+                guard error.localizedDescription.contains(deviceBootedError) else {
+                    return
+                }
+                completionQueue.async {
+                    completion(error)
+                }
+            }
+        }
+    }
 }
 
 // MARK: iOS Methods
@@ -232,7 +258,7 @@ extension DeviceService {
         }
     }
     
-    static func launchDevice(uuid: String) throws {
+    private static func launchDevice(uuid: String) throws {
         do {
             try self.launchSimulatorApp(uuid: uuid)
             try shellOut(to: ProcessPaths.xcrun.rawValue, arguments: ["simctl", "boot", uuid])
@@ -293,7 +319,7 @@ extension DeviceService {
 
 // MARK: Android Methods
 extension DeviceService {
-    static func launchDevice(name: String, additionalArguments: [String] = []) throws {
+    private static func launchDevice(name: String, additionalArguments: [String] = []) throws {
         let emulatorPath = try ADB.getEmulatorPath()
         var arguments = ["@\(name)"]
         let formattedArguments = additionalArguments.filter({ !$0.isEmpty }).map {


### PR DESCRIPTION
This PR is intended to improve codebase by removing explicit queue usage when `DeviceService` functions are called from UI. Additionally, it adopts modern Swift Concurrency to remove queues from `DeviceService` and retain simplicity of business logic in this service.