### PR TITLE
Removing queues from UI

### DIFF
--- a/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
+++ b/MiniSim/AppleScript Commands/LaunchDeviceCommand.swift
@@ -30,19 +30,11 @@ class LaunchDeviceCommand: NSScriptCommand {
                 return nil
             }
             
-            DispatchQueue.global(qos: .userInitiated).async {
-                if device.platform == .android {
-                    try? DeviceService.launchDevice(name: device.name)
-                } else {
-                    try? DeviceService.launchDevice(uuid: device.ID ?? "")
-                }
-            }
-            
+            DeviceService.launch(device: device) { _ in }
             return nil
         } catch {
             scriptErrorNumber = NSInternalScriptError;
             return nil
         }
-        
     }
 }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -35,12 +35,6 @@ class Menu: NSMenu {
     
     func getDevices() {
         let userDefaults = UserDefaults.standard
-        guard userDefaults.enableiOSSimulators,
-              userDefaults.enableAndroidEmulators,
-              userDefaults.androidHome != nil else {
-            return
-        }
-
         DeviceService.getAllDevices(
             android: userDefaults.enableAndroidEmulators && userDefaults.androidHome != nil,
             iOS: userDefaults.enableiOSSimulators

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -105,7 +105,9 @@ class Menu: NSMenu {
     private func assignKeyEquivalent(devices: [NSMenuItem]) {
         for (index, item) in devices.enumerated() {
             if index > maxKeyEquivalent {
-                item.keyEquivalent = ""
+                DispatchQueue.main.async {
+                    item.keyEquivalent = ""
+                }
                 continue
             }
             
@@ -127,9 +129,13 @@ class Menu: NSMenu {
         for (index, device) in sortedDevices.enumerated() {
             let isAndroid = device.platform == .android
             if let itemIndex = items.firstIndex(where: { $0.title == device.displayName }) {
-                let item = self.items.get(at: itemIndex)
-                item?.state = device.booted ? .on : .off
-                item?.submenu = isAndroid ? populateAndroidSubMenu(booted: device.booted) : populateIOSSubMenu(booted: device.booted)
+                DispatchQueue.main.async {
+                    let item = self.items.get(at: itemIndex)
+                    item?.state = device.booted ? .on : .off
+                    item?.submenu = isAndroid ?
+                    self.populateAndroidSubMenu(booted: device.booted) :
+                    self.populateIOSSubMenu(booted: device.booted)
+                }
                 continue
             }
             

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -39,7 +39,7 @@ class Menu: NSMenu {
             android: userDefaults.enableAndroidEmulators && userDefaults.androidHome != nil,
             iOS: userDefaults.enableiOSSimulators
         ) { devices, error in
-            if let error = error {
+            if let error {
                 NSAlert.showError(message: error.localizedDescription)
                 return
             }
@@ -79,7 +79,7 @@ class Menu: NSMenu {
         }
         
         DeviceService.launch(device: device) { error in
-            if let error = error {
+            if let error {
                 NSAlert.showError(message: error.localizedDescription)
             }
         }
@@ -118,7 +118,9 @@ class Menu: NSMenu {
             }
             
             if self.items.contains(item) {
-                item.keyEquivalent = keyEquivalent
+                DispatchQueue.main.async {
+                    item.keyEquivalent = keyEquivalent
+                }
             }
         }
     }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -105,9 +105,7 @@ class Menu: NSMenu {
     private func assignKeyEquivalent(devices: [NSMenuItem]) {
         for (index, item) in devices.enumerated() {
             if index > maxKeyEquivalent {
-                DispatchQueue.main.async {
-                    item.keyEquivalent = ""
-                }
+                item.keyEquivalent = ""
                 continue
             }
             
@@ -118,26 +116,22 @@ class Menu: NSMenu {
             }
             
             if self.items.contains(item) {
-                DispatchQueue.main.async {
-                    item.keyEquivalent = keyEquivalent
-                }
+                item.keyEquivalent = keyEquivalent
             }
         }
     }
-
+    
     
     private func populateDevices(isFirst: Bool) {
         let sortedDevices = devices.sorted(by: { $0.platform == .android && $1.platform == .ios })
         for (index, device) in sortedDevices.enumerated() {
             let isAndroid = device.platform == .android
             if let itemIndex = items.firstIndex(where: { $0.title == device.displayName }) {
-                DispatchQueue.main.async {
-                    let item = self.items.get(at: itemIndex)
-                    item?.state = device.booted ? .on : .off
-                    item?.submenu = isAndroid ?
-                    self.populateAndroidSubMenu(booted: device.booted) :
-                    self.populateIOSSubMenu(booted: device.booted)
-                }
+                let item = self.items.get(at: itemIndex)
+                item?.state = device.booted ? .on : .off
+                item?.submenu = isAndroid ?
+                self.populateAndroidSubMenu(booted: device.booted) :
+                self.populateIOSSubMenu(booted: device.booted)
                 continue
             }
             

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -78,22 +78,16 @@ class Menu: NSMenu {
     
     @objc private func deviceItemClick(_ sender: NSMenuItem) {
         guard let device = getDeviceByName(name: sender.title) else { return }
-        guard let tag = DeviceMenuItem(rawValue: sender.tag) else { return }
         
         if device.booted {
             DeviceService.focusDevice(device)
             return
         }
         
-        do {
-            switch tag {
-            case .launchAndroid:
-                try DeviceService.launchDevice(name: device.name)
-            case .launchIOS:
-                try DeviceService.launchDevice(uuid: device.ID ?? "")
+        DeviceService.launch(device: device) { error in
+            if let error = error {
+                NSAlert.showError(message: error.localizedDescription)
             }
-        } catch {
-            NSAlert.showError(message: error.localizedDescription)
         }
     }
     

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -148,19 +148,18 @@ class MiniSim: NSObject {
                 if !shouldDelete {
                     return
                 }
-                DispatchQueue.global(qos: .userInitiated).async {
-                    do {
-                        let amountCleared = try DeviceService.clearDerivedData()
-                        UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
-                        NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
-                    } catch {
-                        NSAlert.showError(message: error.localizedDescription)
+
+                DeviceService.clearDerivedData() { amountCleared, error in
+                    guard error == nil else {
+                        NSAlert.showError(message: error?.localizedDescription ?? "Failed to clear derived  data.")
+                        return
                     }
+                    UNUserNotificationCenter.showNotification(title: "Derived data has been cleared!", body: "Removed \(amountCleared) of data")
+                    NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
                 }
             default:
                 break
             }
-            
         }
     }
     

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -31,7 +31,7 @@ protocol DeviceServiceProtocol {
 
 class DeviceService: DeviceServiceProtocol {
     
-    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .userInitiated)
+    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .userInteractive)
     private static let deviceBootedError = "Unable to boot device in current state: Booted"
     
     private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -31,7 +31,7 @@ protocol DeviceServiceProtocol {
 
 class DeviceService: DeviceServiceProtocol {
     
-    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .utility)
+    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .userInitiated)
     private static let deviceBootedError = "Unable to boot device in current state: Booted"
     
     private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -155,6 +155,32 @@ class DeviceService: DeviceServiceProtocol {
         UNUserNotificationCenter.showNotification(title: title, body: message)
         NotificationCenter.default.post(name: .commandDidSucceed, object: nil)
     }
+    
+    static func getAllDevices(
+        android: Bool,
+        iOS: Bool,
+        completionQueue: DispatchQueue = .main,
+        completion: @escaping ([Device], Error?) -> ()
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                var devicesArray: [Device] = []
+                if android {
+                    try devicesArray.append(contentsOf: getAndroidDevices())
+                }
+                if iOS {
+                    try devicesArray.append(contentsOf: getIOSDevices())
+                }
+                completionQueue.async {
+                    completion(devicesArray, nil)
+                }
+            } catch {
+                completionQueue.async {
+                    completion([], error)
+                }
+            }
+        }
+    }
 }
 
 // MARK: iOS Methods

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -163,12 +163,15 @@ class DeviceService: DeviceServiceProtocol {
         queue.async {
             do {
                 var devicesArray: [Device] = []
+                
                 if android {
                     try devicesArray.append(contentsOf: getAndroidDevices())
                 }
+                
                 if iOS {
                     try devicesArray.append(contentsOf: getIOSDevices())
                 }
+                
                 completionQueue.async {
                     completion(devicesArray, nil)
                 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -31,6 +31,7 @@ protocol DeviceServiceProtocol {
 
 class DeviceService: DeviceServiceProtocol {
     
+    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .utility)
     private static let deviceBootedError = "Unable to boot device in current state: Booted"
     
     private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"
@@ -90,7 +91,7 @@ class DeviceService: DeviceServiceProtocol {
     }
     
     static func focusDevice(_ device: Device) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        queue.async {
             
             let runningApps = NSWorkspace.shared.runningApplications.filter({$0.activationPolicy == .regular})
             
@@ -159,7 +160,7 @@ class DeviceService: DeviceServiceProtocol {
         completionQueue: DispatchQueue = .main,
         completion: @escaping ([Device], Error?) -> ()
     ) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        queue.async {
             do {
                 var devicesArray: [Device] = []
                 if android {
@@ -299,7 +300,7 @@ extension DeviceService {
             if !NSAlert.showQuestionDialog(title: "Are you sure?", message: "Are you sure you want to delete this Simulator?") {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            queue.async {
                 do {
                     try DeviceService.deleteSimulator(uuid: deviceID)
                     DeviceService.showSuccessMessage(title: "Simulator deleted!", message: deviceID)
@@ -312,7 +313,7 @@ extension DeviceService {
             guard let command = DeviceService.getCustomCommand(platform: .ios, commandName: itemName) else {
                 return
             }
-            DispatchQueue.global(qos: .userInitiated).async {
+            queue.async {
                 do {
                     try DeviceService.runCustomCommand(device, command: command)
                 } catch {


### PR DESCRIPTION
This PR is intended to improve codebase by removing explicit queue usage when DeviceService functions are called from UI. Existing async functions are changed to accept callback closure and queue, where this closure should be executed.