### PR TITLE
fix: correctly show errors when launching devices

### DIFF
--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -201,7 +201,7 @@ class DeviceService: DeviceServiceProtocol {
                 }
             }
             catch {
-                guard error.localizedDescription.contains(deviceBootedError) else {
+                if error.localizedDescription.contains(deviceBootedError) {
                     return
                 }
                 completionQueue.async {


### PR DESCRIPTION
This PR fixes issue when errors weren't shown when launching devices for example with a non existent custom parameter.