### PR TITLE
feature: pin emulator to the top of the list

### DIFF
--- a/MiniSim/Extensions/UserDefaults+Configuration.swift
+++ b/MiniSim/Extensions/UserDefaults+Configuration.swift
@@ -15,6 +15,8 @@ extension UserDefaults {
         static let isOnboardingFinished = "isOnboardingFinished"
         static let enableiOSSimulators = "enableiOSSimulators"
         static let enableAndroidEmulators = "enableAndroidEmulators"
+        static let pinnediOSSimulators = "pinnediOSSimulators"
+        static let pinnedAndroidEmulators = "pinnedAndroidEmulators"
     }
     
     @objc dynamic public var androidHome: String? {
@@ -46,4 +48,15 @@ extension UserDefaults {
         get { bool(forKey: Keys.enableAndroidEmulators) }
         set { set(newValue, forKey: Keys.enableAndroidEmulators) }
     }
+    
+    public var pinnediOSSimulators: [String]? {
+        get { array(forKey: Keys.pinnediOSSimulators) as? [String] }
+        set { set(newValue, forKey: Keys.pinnediOSSimulators) }
+    }
+    
+    public var pinnedAndroidEmulators: [String]? {
+        get { array(forKey: Keys.pinnedAndroidEmulators) as? [String] }
+        set { set(newValue, forKey: Keys.pinnedAndroidEmulators) }
+    }
+
 }

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -27,6 +27,7 @@ enum SubMenuItems {
         case toggleA11y
         case paste
         case delete
+        case togglePinned
         case customCommand = 200
     }
     
@@ -109,6 +110,17 @@ enum SubMenuItems {
         )
     }
     
+    struct TogglePinToTop: SubMenuActionItem {
+        let title = NSLocalizedString("Pin/unpin to top", comment: "")
+        let tag = Tags.togglePinned.rawValue
+        let bootsDevice = false
+        let needBootedDevice = false
+        let image = NSImage(
+            systemSymbolName: "pin",
+            accessibilityDescription: "Pin or unpin to Top"
+        )
+    }
+    
     struct Delete: SubMenuActionItem {
         let title = NSLocalizedString("Delete simulator", comment: "")
         let tag = Tags.delete.rawValue
@@ -128,6 +140,7 @@ extension SubMenuItems {
         
         Separator(),
         
+        TogglePinToTop(),
         ColdBoot(),
         NoAudio(),
         ToggleA11y(),
@@ -140,6 +153,7 @@ extension SubMenuItems {
         
         Separator(),
         
+        TogglePinToTop(),
         Delete()
     ]
 }

--- a/MiniSim/Model/Device.swift
+++ b/MiniSim/Model/Device.swift
@@ -11,30 +11,33 @@ struct Device: Hashable, Codable {
     var ID: String?
     var booted: Bool = false
     var platform: Platform
+    var pinned: Bool
     
     var displayName: String {
+        let pinIcon = pinned ? " 📌" : ""
         switch platform {
         case .ios:
             if let version {
-                return "\(name) - (\(version))"
+                return "\(name) - (\(version))" + pinIcon
             }
-            return name
+            return name + pinIcon
             
         case .android:
-            return name
+            return name + pinIcon
         }
     }
     
     enum CodingKeys: String, CodingKey {
-        case name, version, ID, booted, platform, displayName
+        case name, version, ID, booted, platform, displayName, pinned
     }
     
-    init(name: String, version: String? = nil, ID: String?, booted: Bool = false, platform: Platform) {
+    init(name: String, version: String? = nil, ID: String?, booted: Bool = false, platform: Platform, pinned: Bool = false) {
         self.name = name
         self.version = version
         self.ID = ID
         self.booted = booted
         self.platform = platform
+        self.pinned = pinned
     }
     
     init(from decoder: Decoder) throws {
@@ -44,6 +47,7 @@ struct Device: Hashable, Codable {
         ID = try values.decode(String.self, forKey: .ID)
         booted = try values.decode(Bool.self, forKey: .booted)
         platform = try values.decode(Platform.self, forKey: .platform)
+        pinned = try values.decode(Bool.self, forKey: .pinned)
     }
     
     func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
This pull request introduces the ability to pin simulators/emulators to the top of the list. It includes changes to the `UserDefaults` extension to store pinned devices, modifications to the `SubMenuItem` structure to add a "TogglePinToTop" action, updates to the `Device` model to include a "pinned" Bool property, and adjustments to the `DeviceService` for toggling the pinned status.

- Users can now pin/unpin simulators and emulators.
- The pinned status is persistent across application sessions.

Note that the menu items are not being sorted currently. I just wanted to create the PR to get an initial feedback on if I am going in the right direction.

Some thoughts:

- It would nice to be able to change `SubMenuActionItem` or the content of `SubMenuActionItem` based on the state of the Device. Example: `Pin to top` label and icon could change to `Unpin to top` based on the device state.
- It would be nice if we could store the device list in a state and updating the state would automatically update the UI.

Please provide your feedback @okwasniewski @Garfeild 

Closes #70 