### PR TITLE
feature: delete android emulator 

### DIFF
--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -119,9 +119,9 @@ enum SubMenuItems {
             accessibilityDescription: "Delete simulator"
         )
     }
-    
+
     struct DeleteEmulator: SubMenuActionItem {
-        let title = NSLocalizedString("Delete Emulator", comment: "")
+        let title = NSLocalizedString("Delete emulator", comment: "")
         let tag = Tags.delete.rawValue
         let bootsDevice = false
         let needBootedDevice = false
@@ -129,7 +129,6 @@ enum SubMenuItems {
             systemSymbolName: "trash",
             accessibilityDescription: "Delete emulator"
         )
-                
     }
 }
 

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -127,7 +127,7 @@ enum SubMenuItems {
         let needBootedDevice = false
         let image = NSImage(
             systemSymbolName: "trash",
-            accessibilityDescription: "Delete simulator"
+            accessibilityDescription: "Delete emulator"
         )
                 
     }

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -119,6 +119,18 @@ enum SubMenuItems {
             accessibilityDescription: "Delete simulator"
         )
     }
+    
+    struct DeleteEmulator: SubMenuActionItem {
+        let title = NSLocalizedString("Delete Emulator", comment: "")
+        let tag = Tags.delete.rawValue
+        let bootsDevice = false
+        let needBootedDevice = false
+        let image = NSImage(
+            systemSymbolName: "trash",
+            accessibilityDescription: "Delete simulator"
+        )
+                
+    }
 }
 
 extension SubMenuItems {
@@ -131,7 +143,8 @@ extension SubMenuItems {
         ColdBoot(),
         NoAudio(),
         ToggleA11y(),
-        Paste()
+        Paste(),
+        DeleteEmulator()
     ]
 
     static var ios: [SubMenuItem] = [

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -47,7 +47,7 @@ final class ADB: ADBProtocol {
     static func getAdbPath() throws -> String {
         try getAndroidHome() + Paths.adb.rawValue
     }
-    
+
     static func getAvdPath() throws -> String {
         try getAndroidHome() + Paths.avd.rawValue
     }

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -24,6 +24,7 @@ final class ADB: ADBProtocol {
         case home = "/Android/sdk"
         case emulator = "/emulator/emulator"
         case adb = "/platform-tools/adb"
+        case avd = "/cmdline-tools/latest/bin/avdmanager"
     }
 
     /**
@@ -45,6 +46,10 @@ final class ADB: ADBProtocol {
 
     static func getAdbPath() throws -> String {
         try getAndroidHome() + Paths.adb.rawValue
+    }
+    
+    static func getAvdPath() throws -> String {
+        try getAndroidHome() + Paths.avd.rawValue
     }
 
     /**

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -424,7 +424,7 @@ extension DeviceService {
         }
         try shellOut(to: "\(avdPath) delete avd -n \"\(device.name)\"")
     }
-    
+
     static func handleAndroidAction(device: Device, commandTag: SubMenuItems.Tags, itemName: String) {
             do {
                 switch commandTag {

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -416,14 +416,10 @@ extension DeviceService {
     static func deleteEmulator(device: Device) throws {
         let avdPath = try ADB.getAvdPath()
         let adbPath = try ADB.getAdbPath()
-        
-        let activeDevices = try shellOut(to: "\(adbPath) devices")
-        guard let deviceId = device.identifier else {
-            throw DeviceError.deviceNotFound
-        }
-        
-        let isEmulatorActive = activeDevices.contains(deviceId)
-        if isEmulatorActive{
+        if device.booted {
+            guard let deviceId = device.identifier else {
+                throw DeviceError.deviceNotFound
+            }
             try shellOut(to: "\(adbPath) -s \(deviceId) emu kill")
         }
         try shellOut(to: "\(avdPath) delete avd -n \"\(device.name)\"")
@@ -462,7 +458,7 @@ extension DeviceService {
                     if let command = DeviceService.getCustomCommand(platform: .android, commandName: itemName) {
                         try DeviceService.runCustomCommand(device, command: command)
                     }
-                    
+
                 case .delete:
                     let result = !NSAlert.showQuestionDialog(
                         title: "Are you sure?",
@@ -472,7 +468,7 @@ extension DeviceService {
                     queue.async {
                         do {
                             try DeviceService.deleteEmulator(device: device)
-                            DeviceService.showSuccessMessage(title: "Simulator deleted!", message: device.name)
+                            DeviceService.showSuccessMessage(title: "Emulator deleted!", message: device.name)
                             NotificationCenter.default.post(name: .deviceDeleted, object: nil)
                         } catch {
                             NSAlert.showError(message: error.localizedDescription)


### PR DESCRIPTION
This pull request introduces the ability to delete emulators. #89 
Users can now delete both active(running) emulator and inactive emulators.

Please provide you feedback @okwasniewski