### PR TITLE
fix: make MiniSim dispatch queue concurrent

### DIFF
--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -28,7 +28,11 @@ protocol DeviceServiceProtocol {
 }
 
 class DeviceService: DeviceServiceProtocol {
-    private static let queue = DispatchQueue(label: "com.MiniSim.DeviceService", qos: .userInteractive)
+    private static let queue = DispatchQueue(
+        label: "com.MiniSim.DeviceService",
+        qos: .userInteractive,
+        attributes: .concurrent
+    )
     private static let deviceBootedError = "Unable to boot device in current state: Booted"
 
     private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"


### PR DESCRIPTION
This PR fixes #102 

Previous behaviour before refactor was using `DispatchQueue.global()` which is a concurrent queue. This was causing some emulators not showing as running

Explanation of Concurrent queues: 

> A concurrent queue allows us to execute multiple tasks at the same time. Tasks will always start in the order they’re added but they can finish in a different order as they can be executed in parallel. Tasks will run on distinct threads that are managed by the dispatch queue. The number of tasks running at the same time is variable and depends on system conditions.