### PR TITLE
fix: forcefully focus search controller to show window on MacOS Sonoma

### DIFF
--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -154,6 +154,7 @@ class MiniSim: NSObject {
             switch tag {
             case .preferences:
                 settingsController.show()
+                settingsController.window?.orderFrontRegardless()
             case .quit:
                 NSApp.terminate(sender)
             case .clearDerrivedData:


### PR DESCRIPTION
This PR fixes search controller window not being focused on MacOS Sonoma
