### PR TITLE
fix: apple script integration (#119)

### DIFF
--- a/MiniSim/Extensions/Thread+Asserts.swift
+++ b/MiniSim/Extensions/Thread+Asserts.swift
@@ -2,10 +2,14 @@ import Foundation
 
 extension Thread {
   static func assertMainThread() {
+#if DEBUG
     precondition(Thread.isMainThread, "Not on main thread")
+#endif
   }
 
   static func assertBackgroundThread() {
+#if DEBUG
     precondition(!Thread.isMainThread, "On main thread")
+#endif
   }
 }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -261,6 +261,8 @@ extension DeviceService {
   }
 
   static func getIOSDevices() throws -> [Device] {
+    Thread.assertBackgroundThread()
+
     let output = try shellOut(
       to: ProcessPaths.xcrun.rawValue,
       arguments: ["simctl", "list", "devices", "available"]

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -34,6 +34,7 @@ class DeviceService: DeviceServiceProtocol {
     attributes: .concurrent
   )
   private static let deviceBootedError = "Unable to boot device in current state: Booted"
+  private static let crashDataError = "Storing crashdata"
 
   private static let derivedDataLocation = "~/Library/Developer/Xcode/DerivedData"
 
@@ -395,7 +396,7 @@ extension DeviceService {
     let splitted = output.components(separatedBy: "\n")
 
     return splitted
-      .filter { !$0.isEmpty }
+      .filter { !$0.isEmpty && !$0.contains(crashDataError) }
       .map { deviceName in
         let adbId = try? ADB.getAdbId(for: deviceName, adbPath: adbPath)
         return Device(name: deviceName, identifier: adbId, booted: adbId != nil, platform: .android)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. -->

## Summary:

Fixed Raycast integration not working and MiniSim will now filter out Crash Data Errors (bug introduced in `emulator` utility from Android SDK) #116

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

- fix: Apple Script Integration
- fix: Parse out Emulator Crash Data errors from devices list

## Test Plan:

- 
