### PR TITLE
feat: add physical devices support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -74,6 +74,9 @@ opt_in_rules:
   - weak_delegate
   - yoda_condition
   
+disabled_rules:
+  - nesting
+
 identifier_name:
   excluded: # excluded via string array
     - id

--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		76F2A914299050F9002D4EF6 /* UserDefaults+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2A913299050F9002D4EF6 /* UserDefaults+Configuration.swift */; };
 		76F2A9172991B7B6002D4EF6 /* ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2A9162991B7B6002D4EF6 /* ViewModifiers.swift */; };
 		76FCABAB29B390D5003BBF9A /* Collection+get.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FCABAA29B390D5003BBF9A /* Collection+get.swift */; };
+		9B225A9C2C7E360D002620BA /* DeviceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B225A9B2C7E360D002620BA /* DeviceType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -177,6 +178,7 @@
 		76F2A913299050F9002D4EF6 /* UserDefaults+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Configuration.swift"; sourceTree = "<group>"; };
 		76F2A9162991B7B6002D4EF6 /* ViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModifiers.swift; sourceTree = "<group>"; };
 		76FCABAA29B390D5003BBF9A /* Collection+get.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+get.swift"; sourceTree = "<group>"; };
+		9B225A9B2C7E360D002620BA /* DeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -253,6 +255,7 @@
 				763121882A12AF9C00EE7F48 /* Command.swift */,
 				7631218A2A12AFBC00EE7F48 /* Platform.swift */,
 				76F269862A2A39D100424BDA /* Variables.swift */,
+				9B225A9B2C7E360D002620BA /* DeviceType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -634,6 +637,7 @@
 				7684FAAF29D202F500230BB0 /* AndroidHomeError.swift in Sources */,
 				76C1396A2C849A3F006CD80C /* MenuIcons.swift in Sources */,
 				55CDB0782B1B6D24002418D7 /* TerminalApps.swift in Sources */,
+				9B225A9C2C7E360D002620BA /* DeviceType.swift in Sources */,
 				7645D4BE2982A1B100019227 /* DeviceService.swift in Sources */,
 				765ABF382A8BECD900A063CB /* ExecuteCommand.swift in Sources */,
 			);

--- a/MiniSim/AppleScript Commands/ExecuteCommand.swift
+++ b/MiniSim/AppleScript Commands/ExecuteCommand.swift
@@ -13,6 +13,8 @@ class ExecuteCommand: NSScriptCommand {
         guard
             let platformArg = self.property(forKey: "platform") as? String,
             let platform = Platform(rawValue: platformArg),
+            let deviceTypeArg = self.property(forKey: "deviceType") as? String,
+            let deviceType = DeviceType(rawValue: deviceTypeArg),
             let tag = self.property(forKey: "commandTag") as? String,
             let commandName = self.property(forKey: "commandName") as? String,
             let deviceName = self.property(forKey: "deviceName") as? String,
@@ -22,7 +24,7 @@ class ExecuteCommand: NSScriptCommand {
             return nil
         }
 
-        let device = Device(name: deviceName, identifier: deviceId, platform: platform)
+        let device = Device(name: deviceName, identifier: deviceId, platform: platform, deviceType: deviceType)
         let rawTag = Int(tag) ?? 0
 
         guard let menuItem = SubMenuItems.Tags(rawValue: rawTag) else {

--- a/MiniSim/AppleScript Commands/ExecuteCommand.swift
+++ b/MiniSim/AppleScript Commands/ExecuteCommand.swift
@@ -24,7 +24,7 @@ class ExecuteCommand: NSScriptCommand {
             return nil
         }
 
-        let device = Device(name: deviceName, identifier: deviceId, platform: platform, deviceType: deviceType)
+        let device = Device(name: deviceName, identifier: deviceId, platform: platform, type: deviceType)
         let rawTag = Int(tag) ?? 0
 
         guard let menuItem = SubMenuItems.Tags(rawValue: rawTag) else {

--- a/MiniSim/AppleScript Commands/GetCommands.swift
+++ b/MiniSim/AppleScript Commands/GetCommands.swift
@@ -11,14 +11,17 @@ import Foundation
 class GetCommands: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard
-            let argument = self.property(forKey: "platform") as? String,
-            let platform = Platform(rawValue: argument)
+            let platformArg = self.property(forKey: "platform") as? String,
+            let platform = Platform(rawValue: platformArg),
+            let deviceTypeArg = self.property(forKey: "deviceType") as? String,
+            let deviceType = DeviceType(rawValue: deviceTypeArg)
+
         else {
             scriptErrorNumber = NSRequiredArgumentsMissingScriptError
             return nil
         }
 
-        let commands = platform.subMenuItems
+        let commands = SubMenuItems.items(platform: platform, deviceType: deviceType)
             .compactMap { $0 as? SubMenuActionItem }
             .map { $0.commandItem }
         let customCommands = DeviceService.getCustomCommands(platform: platform)

--- a/MiniSim/AppleScript Commands/GetDevicesCommand.swift
+++ b/MiniSim/AppleScript Commands/GetDevicesCommand.swift
@@ -11,19 +11,25 @@ import Foundation
 class GetDevicesCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard
-            let argument = self.property(forKey: "platform") as? String,
-            let platform = Platform(rawValue: argument)
+            let platformArg = self.property(forKey: "platform") as? String,
+            let platform = Platform(rawValue: platformArg),
+            let deviceTypeArg = self.property(forKey: "deviceType") as? String,
+            let deviceType = DeviceType(rawValue: deviceTypeArg)
         else {
             scriptErrorNumber = NSRequiredArgumentsMissingScriptError
             return nil
         }
 
         do {
-            switch platform {
-            case .android:
-                return try self.encode(DeviceService.getAndroidDevices())
-            case .ios:
-                return try self.encode(DeviceService.getIOSDevices())
+            switch (platform, deviceType) {
+            case (.android, .physical):
+                return try self.encode(DeviceService.getAndroidPhysicalDevices())
+            case (.android, .virtual):
+                return try self.encode(DeviceService.getAndroidEmulators())
+            case (.ios, .physical):
+                return try self.encode(DeviceService.getIOSPhysicalDevices())
+            case (.ios, .virtual):
+                return try self.encode(DeviceService.getIOSSimulators())
             }
         } catch {
             scriptErrorNumber = NSInternalScriptError

--- a/MiniSim/AppleScript Commands/MiniSim.sdef
+++ b/MiniSim/AppleScript Commands/MiniSim.sdef
@@ -14,6 +14,9 @@
             <parameter code="plat" name="platform" description="Platform to get. Can be either android | ios." type="text">
                 <cocoa key="platform"/>
             </parameter>
+            <parameter code="devT" name="deviceType" description="DeviceType to get. Can be either physical | virtual" type="text">
+                <cocoa key="deviceType"/>
+            </parameter>
             <result type="text" description="JSON string with devices."/>
         </command>
         
@@ -31,6 +34,9 @@
             <access-group identifier="*"/>
             <parameter code="plat" name="platform" description="Platform to get. Can be either android | ios." type="text">
                 <cocoa key="platform"/>
+            </parameter>
+            <parameter code="devT" name="deviceType" description="DeviceType to get. Can be either physical | virtual" type="text">
+                <cocoa key="deviceType"/>
             </parameter>
             <result type="text" description="Response code"/>
         </command>
@@ -52,6 +58,9 @@
             </parameter>
             <parameter code="devI" name="deviceId" description="Unique identifier of the device." type="text">
                 <cocoa key="deviceId"/>
+            </parameter>
+            <parameter code="devT" name="deviceType" description="DeviceType to get. Can be either physical | virtual" type="text">
+                <cocoa key="deviceType"/>
             </parameter>
             <result type="text" description="Response code"/>
         </command>

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -205,6 +205,10 @@ class Menu: NSMenu {
             return
         }
 
+        let isEmpty = items.isEmpty
+        self.items[startIndex].isHidden = isEmpty
+        guard !isEmpty else { return }
+
         for menuItem in items.reversed() {
             if let itemIndex = self.items.firstIndex(where: { $0.title == menuItem.title }) {
                 self.replaceMenuItem(at: itemIndex, with: menuItem)

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -241,9 +241,10 @@ class Menu: NSMenu {
     func buildSubMenu(for device: Device) -> NSMenu {
         let subMenu = NSMenu()
         let platform = device.platform
+        let deviceType = device.type
         let callback = platform == .android ? #selector(androidSubMenuClick) : #selector(IOSSubMenuClick)
         let actionsSubMenu = createActionsSubMenu(
-            for: platform.subMenuItems,
+            for: SubMenuItems.items(platform: platform, deviceType: deviceType),
             isDeviceBooted: device.booted,
             callback: callback
         )
@@ -324,16 +325,5 @@ extension Menu: NSMenuDelegate {
     func menuDidClose(_ menu: NSMenu) {
         NotificationCenter.default.post(name: .menuDidClose, object: nil)
         KeyboardShortcuts.enable(.toggleMiniSim)
-    }
-}
-
-extension Platform {
-    var subMenuItems: [SubMenuItem] {
-        switch self {
-        case .android:
-            return SubMenuItems.android
-        case .ios:
-            return SubMenuItems.ios
-        }
     }
 }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -108,7 +108,7 @@ class Menu: NSMenu {
     }
 
     @objc private func deviceItemClick(_ sender: NSMenuItem) {
-        guard let device = getDeviceByName(name: sender.title) else { return }
+        guard let device = getDeviceByName(name: sender.title), device.type == .virtual else { return }
 
         if device.booted {
             DeviceService.focusDevice(device)

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -35,12 +35,15 @@ class Menu: NSMenu {
 
     func populateDefaultMenu() {
         var sections: [DeviceListSection] = []
+
+        sections.append(.iOSPhysical)
         if UserDefaults.standard.enableiOSSimulators {
-            sections.append(.iOS)
+            sections.append(.iOSVirtual)
         }
 
+        sections.append(.androidPhysical)
         if UserDefaults.standard.enableAndroidEmulators {
-            sections.append(.android)
+            sections.append(.androidVirtual)
         }
 
         if sections.isEmpty {
@@ -170,17 +173,30 @@ class Menu: NSMenu {
         var sections: [DeviceListSection] = []
 
         if UserDefaults.standard.enableAndroidEmulators {
-            sections.append(.android)
+            sections.append(.androidVirtual)
         }
+        sections.append(.androidPhysical)
+
         if UserDefaults.standard.enableiOSSimulators {
-            sections.append(.iOS)
+            sections.append(.iOSVirtual)
         }
+        sections.append(.iOSPhysical)
         return sections
     }
 
     private func filter(devices: [Device], for section: DeviceListSection) -> [Device] {
-        let platform: Platform = section == .iOS ? .ios : .android
-        return devices.filter { $0.platform == platform }
+      devices.filter { device in
+        switch section {
+        case .iOSPhysical:
+          return device.platform == .ios && device.type == .physical
+        case .iOSVirtual:
+          return device.platform == .ios && device.type == .virtual
+        case .androidPhysical:
+          return device.platform == .android && device.type == .physical
+        case .androidVirtual:
+          return device.platform == .android && device.type == .virtual
+        }
+      }
     }
 
     private func updateSection(with items: [NSMenuItem], section: DeviceListSection) {

--- a/MiniSim/MenuItems/DeviceListSection.swift
+++ b/MiniSim/MenuItems/DeviceListSection.swift
@@ -8,15 +8,21 @@
 import Foundation
 
 enum DeviceListSection: Int, CaseIterable {
-    case iOS = 100
-    case android
+    case iOSPhysical = 100
+    case iOSVirtual
+    case androidPhysical
+    case androidVirtual
 
     var title: String {
         switch self {
-        case .iOS:
+        case .iOSPhysical:
+            return NSLocalizedString("iOS Devices", comment: "")
+        case .iOSVirtual:
             return NSLocalizedString("iOS Simulator", comment: "")
-        case .android:
+        case .androidVirtual:
             return NSLocalizedString("Android Simulator", comment: "")
+        case .androidPhysical:
+            return NSLocalizedString("Android Devices", comment: "")
         }
     }
 }

--- a/MiniSim/MenuItems/DeviceListSection.swift
+++ b/MiniSim/MenuItems/DeviceListSection.swift
@@ -18,9 +18,9 @@ enum DeviceListSection: Int, CaseIterable {
         case .iOSPhysical:
             return NSLocalizedString("iOS Devices", comment: "")
         case .iOSVirtual:
-            return NSLocalizedString("iOS Simulator", comment: "")
+            return NSLocalizedString("iOS Simulators", comment: "")
         case .androidVirtual:
-            return NSLocalizedString("Android Simulator", comment: "")
+            return NSLocalizedString("Android Emulators", comment: "")
         case .androidPhysical:
             return NSLocalizedString("Android Devices", comment: "")
         }

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -145,26 +145,54 @@ enum SubMenuItems {
 }
 
 extension SubMenuItems {
-    static var android: [SubMenuItem] = [
-        CopyName(),
-        CopyID(),
+  static func items(platform: Platform, deviceType: DeviceType) -> [SubMenuItem] {
+    switch platform {
+    case .ios:
+      switch deviceType {
+      case .physical:
+        return [
+          CopyName(),
+          CopyUDID()
+        ]
+      case .virtual:
+        return [
+          CopyName(),
+          CopyUDID(),
 
-        Separator(),
+          Separator(),
 
-        ColdBoot(),
-        NoAudio(),
-        ToggleA11y(),
-        Paste(),
-        DeleteEmulator(),
-        LaunchLogCat()
-    ]
+          Delete()
+        ]
+      }
+    case .android:
+      switch deviceType {
+      case .physical:
+        return [
+          CopyName(),
+          CopyID(),
 
-    static var ios: [SubMenuItem] = [
-        CopyName(),
-        CopyUDID(),
+          Separator(),
 
-        Separator(),
+          ToggleA11y(),
+          Paste(),
+          LaunchLogCat()
+        ]
 
-        Delete()
-    ]
+      case .virtual:
+        return [
+          CopyName(),
+          CopyID(),
+
+          Separator(),
+
+          ColdBoot(),
+          NoAudio(),
+          ToggleA11y(),
+          Paste(),
+          DeleteEmulator(),
+          LaunchLogCat()
+        ]
+      }
+    }
+  }
 }

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -146,53 +146,47 @@ enum SubMenuItems {
 
 extension SubMenuItems {
   static func items(platform: Platform, deviceType: DeviceType) -> [SubMenuItem] {
-    switch platform {
-    case .ios:
-      switch deviceType {
-      case .physical:
-        return [
-          CopyName(),
-          CopyUDID()
-        ]
-      case .virtual:
-        return [
-          CopyName(),
-          CopyUDID(),
+    switch (platform, deviceType) {
+    case (.ios, .physical):
+      return [
+        CopyName(),
+        CopyUDID()
+      ]
+    case (.ios, .virtual):
+      return [
+        CopyName(),
+        CopyUDID(),
 
-          Separator(),
+        Separator(),
 
-          Delete()
-        ]
-      }
-    case .android:
-      switch deviceType {
-      case .physical:
-        return [
-          CopyName(),
-          CopyID(),
+        Delete()
+      ]
+    case (.android, .physical):
+      return [
+        CopyName(),
+        CopyID(),
 
-          Separator(),
+        Separator(),
 
-          ToggleA11y(),
-          Paste(),
-          LaunchLogCat()
-        ]
+        ToggleA11y(),
+        Paste(),
+        LaunchLogCat()
+      ]
 
-      case .virtual:
-        return [
-          CopyName(),
-          CopyID(),
+    case (.android, .virtual):
+      return [
+        CopyName(),
+        CopyID(),
 
-          Separator(),
+        Separator(),
 
-          ColdBoot(),
-          NoAudio(),
-          ToggleA11y(),
-          Paste(),
-          DeleteEmulator(),
-          LaunchLogCat()
-        ]
-      }
+        ColdBoot(),
+        NoAudio(),
+        ToggleA11y(),
+        Paste(),
+        DeleteEmulator(),
+        LaunchLogCat()
+      ]
     }
   }
 }

--- a/MiniSim/Model/Device.swift
+++ b/MiniSim/Model/Device.swift
@@ -11,6 +11,7 @@ struct Device: Hashable, Codable {
     var identifier: String?
     var booted: Bool
     var platform: Platform
+    var type: DeviceType
 
     var displayName: String {
         switch platform {
@@ -26,15 +27,23 @@ struct Device: Hashable, Codable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case name, version, identifier, booted, platform, displayName
+        case name, version, identifier, booted, platform, displayName, type
     }
 
-    init(name: String, version: String? = nil, identifier: String?, booted: Bool = false, platform: Platform) {
+  init(
+    name: String,
+    version: String? = nil,
+    identifier: String?,
+    booted: Bool = false,
+    platform: Platform,
+    deviceType: DeviceType
+  ) {
         self.name = name
         self.version = version
         self.identifier = identifier
         self.booted = booted
         self.platform = platform
+        self.type = deviceType
     }
 
     init(from decoder: Decoder) throws {
@@ -44,6 +53,7 @@ struct Device: Hashable, Codable {
         identifier = try values.decode(String.self, forKey: .identifier)
         booted = try values.decode(Bool.self, forKey: .booted)
         platform = try values.decode(Platform.self, forKey: .platform)
+        type = try values.decode(DeviceType.self, forKey: .platform)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -54,5 +64,6 @@ struct Device: Hashable, Codable {
         try container.encode(booted, forKey: .booted)
         try container.encode(platform, forKey: .platform)
         try container.encode(displayName, forKey: .displayName)
+        try container.encode(type, forKey: .type)
     }
 }

--- a/MiniSim/Model/Device.swift
+++ b/MiniSim/Model/Device.swift
@@ -36,14 +36,14 @@ struct Device: Hashable, Codable {
     identifier: String?,
     booted: Bool = false,
     platform: Platform,
-    deviceType: DeviceType
+    type: DeviceType
   ) {
         self.name = name
         self.version = version
         self.identifier = identifier
         self.booted = booted
         self.platform = platform
-        self.type = deviceType
+        self.type = type
     }
 
     init(from decoder: Decoder) throws {
@@ -53,7 +53,7 @@ struct Device: Hashable, Codable {
         identifier = try values.decode(String.self, forKey: .identifier)
         booted = try values.decode(Bool.self, forKey: .booted)
         platform = try values.decode(Platform.self, forKey: .platform)
-        type = try values.decode(DeviceType.self, forKey: .platform)
+        type = try values.decode(DeviceType.self, forKey: .type)
     }
 
     func encode(to encoder: Encoder) throws {

--- a/MiniSim/Model/DeviceType.swift
+++ b/MiniSim/Model/DeviceType.swift
@@ -1,0 +1,13 @@
+//
+//  DeviceType.swift
+//  MiniSim
+//
+//  Created by Rami Elwan on 27.08.24.
+//
+
+import Foundation
+
+enum DeviceType: String, Codable {
+  case physical
+  case virtual
+}

--- a/MiniSim/Service/DeviceParser.swift
+++ b/MiniSim/Service/DeviceParser.swift
@@ -108,7 +108,6 @@ class IOSPhysicalDeviceParser: DeviceParser {
   }
 }
 
-
 class AndroidEmulatorParser: DeviceParser {
   let adb: ADBProtocol.Type
 
@@ -155,4 +154,3 @@ class AndroidPhysicalDeviceParser: DeviceParser {
     }
 }
 }
-

--- a/MiniSim/Service/DeviceParser.swift
+++ b/MiniSim/Service/DeviceParser.swift
@@ -129,12 +129,6 @@ class AndroidEmulatorParser: DeviceParser {
 }
 
 class AndroidPhysicalDeviceParser: DeviceParser {
-  let adb: ADBProtocol.Type
-
-  required init(adb: ADBProtocol.Type = ADB.self) {
-    self.adb = adb
-  }
-
   func parse(_ input: String) -> [Device] {
     var splitted = input.components(separatedBy: "\n")
     splitted.removeFirst() // removes 'List of devices attached'

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -232,7 +232,7 @@ extension DeviceService {
       guard isDevice else { continue }
 
       // The version is set as optional which only is the case for the device running
-      // the application, for exmaple your macbook, maybe we can make it not optional
+      // the application, for example your MacBook, maybe we can make it not optional
       // because we filter that device anyway but just in case some other device also has this behavior
       guard let match = line.match("(.+?)\\s(?:\\(([\\d\\.]+)\\))?\\s?\\((\\S+)\\)").first else {
         continue

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -245,10 +245,10 @@ extension DeviceService {
     let tempDirectory = FileManager.default.temporaryDirectory
     let outputFile = tempDirectory.appendingPathComponent("iosPhysicalDevices.json")
 
-    guard let _ = try? shellOut(
+    guard (try? shellOut(
       to: ProcessPaths.xcrun.rawValue,
       arguments: ["devicectl", "list", "devices", "-j \(outputFile.path)"]
-    ) else {
+    )) != nil else {
       return []
     }
 

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -247,7 +247,8 @@ extension DeviceService {
           version: osVersion.isEmpty ? nil : osVersion,
           identifier: identifier,
           booted: isOnline,
-          platform: .ios
+          platform: .ios,
+          deviceType: .physical
         )
       )
     }
@@ -447,7 +448,8 @@ extension DeviceService {
           name: name,
           identifier: id,
           booted: true,
-          platform: .android
+          platform: .android,
+          deviceType: .physical
         )
       }
   }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -248,7 +248,7 @@ extension DeviceService {
           identifier: identifier,
           booted: isOnline,
           platform: .ios,
-          deviceType: .physical
+          type: .physical
         )
       )
     }
@@ -449,7 +449,7 @@ extension DeviceService {
           identifier: id,
           booted: true,
           platform: .android,
-          deviceType: .physical
+          type: .physical
         )
       }
   }

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -451,7 +451,7 @@ extension DeviceService {
       let output = try shellOut(to: adbPath, arguments: ["devices", "-l"])
       var splitted = output.components(separatedBy: "\n")
       splitted.removeFirst() // removes 'List of devices attached'
-      let filtered = splitted.filter { !$0.hasPrefix("emulator-") }
+      let filtered = splitted.filter { !$0.contains("emulator") }
 
       return filtered.compactMap { item -> Device? in
         let serialNoIdx = 0

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -245,10 +245,12 @@ extension DeviceService {
     let tempDirectory = FileManager.default.temporaryDirectory
     let outputFile = tempDirectory.appendingPathComponent("iosPhysicalDevices.json")
 
-    try shellOut(
+    guard let _ = try? shellOut(
       to: ProcessPaths.xcrun.rawValue,
       arguments: ["devicectl", "list", "devices", "-j \(outputFile.path)"]
-    )
+    ) else {
+      return []
+    }
 
     let jsonString = try String(contentsOf: outputFile)
     return DeviceParserFactory().getParser(.iosPhysical).parse(jsonString)

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -449,29 +449,8 @@ extension DeviceService {
   static func getAndroidPhysicalDevices() throws -> [Device] {
       let adbPath = try ADB.getAdbPath()
       let output = try shellOut(to: adbPath, arguments: ["devices", "-l"])
-      var splitted = output.components(separatedBy: "\n")
-      splitted.removeFirst() // removes 'List of devices attached'
-      let filtered = splitted.filter { !$0.contains("emulator") }
 
-      return filtered.compactMap { item -> Device? in
-        let serialNoIdx = 0
-        let modelNameIdx = 4
-        let components = item.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-        guard components.count > 4  else {
-          return nil
-        }
-
-        let id = components[serialNoIdx]
-        let name = components[modelNameIdx].components(separatedBy: ":")[1]
-
-        return Device(
-          name: name,
-          identifier: id,
-          booted: true,
-          platform: .android,
-          type: .physical
-        )
-      }
+    return DeviceParserFactory().getParser(.androidPhysical).parse(output)
   }
 
   static func getAndroidEmulators() throws -> [Device] {

--- a/MiniSim/Service/DeviceService.swift
+++ b/MiniSim/Service/DeviceService.swift
@@ -39,7 +39,6 @@ class DeviceService: DeviceServiceProtocol {
   private enum ProcessPaths: String {
     case xcrun = "/usr/bin/xcrun"
     case xcodeSelect = "/usr/bin/xcode-select"
-    case systemProfiler = "/usr/sbin/system_profiler"
   }
 
   private enum BundleURL: String {

--- a/MiniSimTests/DeviceParserTests.swift
+++ b/MiniSimTests/DeviceParserTests.swift
@@ -75,18 +75,21 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].identifier, "957C8A2F-4C12-4732-A4E9-37F8FDD35E3B")
     XCTAssertTrue(devices[0].booted)
     XCTAssertEqual(devices[0].platform, .ios)
+    XCTAssertEqual(devices[0].type, .virtual)
 
     XCTAssertEqual(devices[1].name, "iPhone 15")
     XCTAssertEqual(devices[1].version, "iOS 17.5")
     XCTAssertEqual(devices[1].identifier, "7B8464FF-956F-405B-B357-8ED4689E5177")
     XCTAssertFalse(devices[1].booted)
     XCTAssertEqual(devices[1].platform, .ios)
+    XCTAssertEqual(devices[1].type, .virtual)
 
     XCTAssertEqual(devices[2].name, "iPhone 15 Plus")
     XCTAssertEqual(devices[2].version, "iOS 17.5")
     XCTAssertEqual(devices[2].identifier, "37A0352D-849D-463B-B513-D23ED0113A87")
     XCTAssertTrue(devices[2].booted)
     XCTAssertEqual(devices[2].platform, .ios)
+    XCTAssertEqual(devices[2].type, .virtual)
   }
 
   func testAndroidEmulatorParser() {
@@ -105,17 +108,72 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].identifier, "mock_adb_id_for_Pixel_3a_API_30_x86")
     XCTAssertTrue(devices[0].booted)
     XCTAssertEqual(devices[0].platform, .android)
+    XCTAssertEqual(devices[0].type, .virtual)
 
     XCTAssertEqual(devices[1].name, "Pixel_4_API_29")
     XCTAssertEqual(devices[1].identifier, "mock_adb_id_for_Pixel_4_API_29")
     XCTAssertTrue(devices[1].booted)
     XCTAssertEqual(devices[1].platform, .android)
+    XCTAssertEqual(devices[1].type, .virtual)
 
     XCTAssertEqual(devices[2].name, "Nexus_5X_API_28")
     XCTAssertEqual(devices[2].identifier, nil)
     XCTAssertFalse(devices[2].booted)
     XCTAssertEqual(devices[2].platform, .android)
+    XCTAssertEqual(devices[2].type, .virtual)
   }
+
+  func testAndroidPhysicalDeviceParser() {
+    let parser = AndroidPhysicalDeviceParser()
+    let emptyInput = """
+        List of devices attached
+
+        """
+
+    var devices = parser.parse(emptyInput)
+    XCTAssertEqual(devices.count, 0)
+
+    let singleEmulatorInput = """
+      List of devices attached
+      emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:3
+
+      """
+
+    devices = parser.parse(singleEmulatorInput)
+    XCTAssertEqual(devices.count, 0)
+
+    let singlePhysicalDeviceInput = """
+      List of devices attached
+      RFCWA0FXXXX            device 0-1 product:a34xdxx model:SM_A346E device:a34x transport_id:5
+
+      """
+
+    devices = parser.parse(singlePhysicalDeviceInput)
+    XCTAssertEqual(devices.count, 1)
+
+    XCTAssertEqual(devices[0].name, "SM_A346E")
+    XCTAssertEqual(devices[0].identifier, "RFCWA0FXXXX")
+    XCTAssertTrue(devices[0].booted)
+    XCTAssertEqual(devices[0].platform, .android)
+    XCTAssertEqual(devices[0].type, .physical)
+
+    let mixedInput = """
+      List of devices attached
+      emulator-5554          device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:3
+      RFCWA0FXXXX            device 0-1 product:a34xdxx model:SM_A346E device:a34x transport_id:5
+
+      """
+
+    devices = parser.parse(mixedInput)
+    XCTAssertEqual(devices.count, 1)
+
+    XCTAssertEqual(devices[0].name, "SM_A346E")
+    XCTAssertEqual(devices[0].identifier, "RFCWA0FXXXX")
+    XCTAssertTrue(devices[0].booted)
+    XCTAssertEqual(devices[0].platform, .android)
+    XCTAssertEqual(devices[0].type, .physical)
+  }
+
 
   func filtersOutEmulatorCrashData() {
     let parser = AndroidEmulatorParser(adb: ADB.self)
@@ -132,6 +190,7 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].identifier, "mock_adb_id_for_Pixel_3a_API_30_x86")
     XCTAssertTrue(devices[0].booted)
     XCTAssertEqual(devices[0].platform, .android)
+    XCTAssertEqual(devices[0].type, .virtual)
 
     XCTAssertNil(devices.first(where: { $0.name.contains("crashdata") }))
   }

--- a/MiniSimTests/DeviceParserTests.swift
+++ b/MiniSimTests/DeviceParserTests.swift
@@ -174,7 +174,6 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].type, .physical)
   }
 
-
   func filtersOutEmulatorCrashData() {
     let parser = AndroidEmulatorParser(adb: ADB.self)
     let input = """
@@ -192,7 +191,7 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].platform, .android)
     XCTAssertEqual(devices[0].type, .virtual)
 
-    XCTAssertNil(devices.first(where: { $0.name.contains("crashdata") }))
+    XCTAssertNil(devices.first { $0.name.contains("crashdata") })
   }
 
   func testAndroidEmulatorParserWithADBFailure() {

--- a/MiniSimTests/DeviceParserTests.swift
+++ b/MiniSimTests/DeviceParserTests.swift
@@ -174,6 +174,87 @@ class DeviceParserTests: XCTestCase {
     XCTAssertEqual(devices[0].type, .physical)
   }
 
+  func testIOSPhysicalDeviceParser() {
+    let parser = IOSPhysicalDeviceParser()
+    let emptyInput = """
+        """
+
+    var devices = parser.parse(emptyInput)
+    XCTAssertEqual(devices.count, 0)
+
+    let invalidInput = """
+      some random text
+      """
+
+    devices = parser.parse(invalidInput)
+    XCTAssertEqual(devices.count, 0)
+
+    let unsuccessfulOutcomeInput = """
+      {
+        "info" : {
+          "outcome" : "success",
+        }
+      }
+      """
+
+    devices = parser.parse(unsuccessfulOutcomeInput)
+    XCTAssertEqual(devices.count, 0)
+
+    let validInput = """
+      {
+        "info" : {
+          "outcome" : "success",
+        },
+        "result" : {
+          "devices" : [
+            {
+              "connectionProperties" : {
+                "tunnelState" : "connected"
+              },
+              "deviceProperties" : {
+                "name" : "Random iPhone 1",
+                "osVersionNumber" : "17.6.1",
+              },
+              "hardwareProperties" : {
+                "udid" : "xxx-xxx-xxx1"
+              },
+            },
+            {
+              "connectionProperties" : {
+                "tunnelState" : "unavailable"
+              },
+              "deviceProperties" : {
+                "name" : "Random iPhone 2",
+                "osVersionNumber" : "17.6.2",
+              },
+              "hardwareProperties" : {
+                "udid" : "xxx-xxx-xxx2"
+              },
+            }
+          ]
+        }
+      }
+      """
+
+    devices = parser.parse(validInput)
+    XCTAssertEqual(devices.count, 2)
+
+    XCTAssertEqual(devices[0].name, "Random iPhone 1")
+    XCTAssertEqual(devices[0].identifier, "xxx-xxx-xxx1")
+    XCTAssertTrue(devices[0].booted)
+    XCTAssertTrue(devices[0].booted)
+    XCTAssertEqual(devices[0].version, "17.6.1")
+    XCTAssertEqual(devices[0].platform, .ios)
+    XCTAssertEqual(devices[0].type, .physical)
+
+    XCTAssertEqual(devices[1].name, "Random iPhone 2")
+    XCTAssertEqual(devices[1].identifier, "xxx-xxx-xxx2")
+    XCTAssertFalse(devices[1].booted)
+    XCTAssertEqual(devices[1].version, "17.6.2")
+    XCTAssertEqual(devices[1].platform, .ios)
+    XCTAssertEqual(devices[1].type, .physical)
+  }
+
   func filtersOutEmulatorCrashData() {
     let parser = AndroidEmulatorParser(adb: ADB.self)
     let input = """


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. -->

## Summary:
### Display physical iOS and Android devices

closes #121 
The idea here to be able to view connected devices.

For iOS, devices are visible even if not connected via cable. The system also marks the device as offline if the device is not connected to the internet and not connected by cable, otherwise it is marked as online. The booted property for iOS physical devices is determined according whether the device is online or not.

For android, connected devices are figured out using `adb devices -l`

Applescript commands are adjusted to account for the changes.
[Link to raycast extension pr](https://github.com/raycast/extensions/pull/14229)

### Motivation
For iOS, this allows you to copy your uuid which can be useful at times or you create a custom command.
For android, you can paste to clipboard(main reason I worked on this pr), launch logcat, and also custom commands.

#### Other changes
I hide sections that do not include any devices which wasnt the case previously. Assuming you are ios dev only that work only with simulators, you would see 3 other empty sections, which I personally think is not nice but that is just my opinion

## Changelog:

feat: display physical ios and android devices
feat: hide sections that include no devices

## Test Plan:

Android

https://github.com/user-attachments/assets/15236eaa-7cd8-4e48-90f2-094f4cc8a9bb

iOS(didnt record video cause would like to keep the uuid private 🤓):
<img width="494" alt="image" src="https://github.com/user-attachments/assets/9bd23f38-305a-45e8-b01c-68d15c17c858">


