### PR TITLE
feat: add option to hold shift when deleting simulators to skip alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,16 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.2.1
 
   build:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 15
+          xcode-version: 16
       - name: Cache DerivedData
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.DERIVED_DATA_PATH }}
           key: ${{ runner.os }}-deriveddata-${{ hashFiles('**/*.xcodeproj/project.pbxproj') }}
@@ -50,16 +50,16 @@ jobs:
 
   test:
     needs: build
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 15
+          xcode-version: 16
       - name: Cache DerivedData
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.DERIVED_DATA_PATH }}
           key: ${{ runner.os }}-deriveddata-${{ hashFiles('**/*.xcodeproj/project.pbxproj') }}

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -98,10 +98,13 @@ class Menu: NSMenu {
       guard let tag = SubMenuItems.Tags(rawValue: sender.tag) else { return }
       guard let device = getDeviceByName(name: sender.parent?.title ?? "") else { return }
 
+      let skipConfirmation = NSEvent.modifierFlags.contains(.shift)
+
       actionExecutor.execute(
         device: device,
         commandTag: tag,
-        itemName: sender.title
+        itemName: sender.title,
+        skipConfirmation: skipConfirmation
       )
     }
 

--- a/MiniSim/Service/ActionExecutor.swift
+++ b/MiniSim/Service/ActionExecutor.swift
@@ -11,7 +11,8 @@ class ActionExecutor {
   func execute(
     device: Device,
     commandTag: SubMenuItems.Tags,
-    itemName: String
+    itemName: String,
+    skipConfirmation: Bool = false
   ) {
     let action: Action
 
@@ -20,13 +21,15 @@ class ActionExecutor {
       action = AndroidActionFactory.createAction(
         for: commandTag,
         device: device,
-        itemName: itemName
+        itemName: itemName,
+        skipConfirmation: skipConfirmation
       )
     case .ios:
       action = IOSActionFactory.createAction(
         for: commandTag,
         device: device,
-        itemName: itemName
+        itemName: itemName,
+        skipConfirmation: skipConfirmation
       )
     }
 

--- a/MiniSim/Service/ActionFactory.swift
+++ b/MiniSim/Service/ActionFactory.swift
@@ -2,11 +2,11 @@ import AppKit
 import Foundation
 
 protocol ActionFactory {
-  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String) -> Action
+  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String, skipConfirmation: Bool) -> Action
 }
 
 class AndroidActionFactory: ActionFactory {
-  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String) -> any Action {
+  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String, skipConfirmation: Bool = false) -> any Action {
     switch tag {
     case .copyName:
       return CopyNameAction(device: device)
@@ -21,7 +21,7 @@ class AndroidActionFactory: ActionFactory {
     case .paste:
       return PasteClipboardAction(device: device)
     case .delete:
-      return DeleteAction(device: device)
+      return DeleteAction(device: device, skipConfirmation: skipConfirmation)
     case .customCommand:
       return CustomCommandAction(device: device, itemName: itemName)
     case .logcat:
@@ -31,7 +31,7 @@ class AndroidActionFactory: ActionFactory {
 }
 
 class IOSActionFactory: ActionFactory {
-  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String) -> any Action {
+  static func createAction(for tag: SubMenuItems.Tags, device: Device, itemName: String, skipConfirmation: Bool = false) -> any Action {
     switch tag {
     case .copyName:
       return CopyNameAction(device: device)
@@ -42,7 +42,7 @@ class IOSActionFactory: ActionFactory {
     case .coldBoot:
       return ColdBootCommand(device: device)
     case .delete:
-      return DeleteAction(device: device)
+      return DeleteAction(device: device, skipConfirmation: skipConfirmation)
     default:
       fatalError("Unhandled action tag: \(tag)")
     }

--- a/MiniSim/Service/Actions.swift
+++ b/MiniSim/Service/Actions.swift
@@ -44,13 +44,16 @@ class CopyNameAction: Action {
 
 class DeleteAction: Action {
   let device: Device
+  let skipConfirmation: Bool
 
-  init(device: Device) {
+  init(device: Device, skipConfirmation: Bool = false) {
     self.device = device
+    self.skipConfirmation = skipConfirmation
   }
 
   func showQuestionDialog() -> Bool {
-    !NSAlert.showQuestionDialog(
+    guard !skipConfirmation else { return false }
+    return !NSAlert.showQuestionDialog(
       title: "Are you sure?",
       message: "Are you sure you want to delete this device?"
     )


### PR DESCRIPTION
## Summary:

This allows to skip alert when deleting simulators. Pressing shift will delete them without prompt

## Changelog:

feat: allow to use shift + click to delete simulators without asking

## Test Plan:

Try deleting simulators holding shift