### PR TITLE
Ghostty Support

### DIFF
--- a/MiniSim/Service/Terminal/Terminal.swift
+++ b/MiniSim/Service/Terminal/Terminal.swift
@@ -22,6 +22,8 @@ class TerminalService: TerminalServiceProtocol {
             return ITermTerminal()
         case .wezterm:
             return WezTermTerminal()
+        case .ghostty:
+            return GhosttyTerminal()
         }
     }
 

--- a/MiniSim/Service/Terminal/TerminalApps.swift
+++ b/MiniSim/Service/Terminal/TerminalApps.swift
@@ -18,6 +18,7 @@ enum Terminal: String, CaseIterable {
     case terminal = "Terminal"
     case iterm = "iTerm"
     case wezterm = "WezTerm"
+    case ghostty = "Ghostty"
 
     var bundleIdentifier: String {
         switch self {
@@ -27,6 +28,8 @@ enum Terminal: String, CaseIterable {
             return "com.googlecode.iterm2"
         case .wezterm:
             return "com.github.wez.wezterm"
+        case .ghostty:
+            return "com.mitchellh.ghostty"
         }
     }
 
@@ -83,6 +86,18 @@ struct WezTermTerminal: TerminalApp {
         """
             tell application \"wezterm\" to activate
             do shell script \"/Applications/WezTerm.app/Contents/MacOS/wezterm cli spawn \(command)\"
+        """
+    }
+}
+
+struct GhosttyTerminal: TerminalApp {
+    var name: String = "Ghostty"
+    var bundleIdentifier: String = "com.mitchellh.ghostty"
+
+    func getLaunchScript(command: String) -> String {
+        """
+            tell application \"Ghostty\" to activate
+            do shell script \"/Applications/Ghostty.app/Contents/MacOS/ghostty -e \(command)\"
         """
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. -->

## Summary:

This PR adds support for Ghostty terminal emulator as a preferred terminal option in MiniSim. Users who have Ghostty installed will now see it as an available option in the preferences alongside Terminal, iTerm, and WezTerm.

## Changelog:

- Add Ghostty to the list of supported terminal emulators
- Ghostty will automatically appear in Preferences > Preferred Terminal if installed

## Test Plan:

**Build Verification:**
  - ✅ Project builds successfully with no errors
  - ✅ All terminal enum cases are handled in switch statements
  

 **Testing Steps:**
  1. Build and run MiniSim
  2. Open Preferences
  3. Navigate to "Preferred Terminal" section
  4. Verify Ghostty appears in the dropdown (if installed on the system)
  5. Select Ghostty as preferred terminal
  6. Launch an Android emulator
  7. Use "Launch Logcat" feature to verify it opens in Ghostty terminal
