### PR TITLE
Fixed - Hardcoded android as device at CustomCommandAction

### DIFF
--- a/MiniSim/Service/Actions.swift
+++ b/MiniSim/Service/Actions.swift
@@ -76,7 +76,7 @@ class CustomCommandAction: Action {
   }
 
   func execute() throws {
-    if let command = CustomCommandService.getCustomCommand(platform: .android, commandName: itemName) {
+    if let command = CustomCommandService.getCustomCommand(platform: device.platform, commandName: itemName) {
       try CustomCommandService.runCustomCommand(device, command: command)
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. -->

## Summary:

Codebase has hardcoded device type as android for CustomCommandAction, remove made it based on device type
Issue raised here : https://github.com/okwasniewski/MiniSim/issues/138

## Changelog:

`CustomCommandAction` - .android to device.platform

## Test Plan:

Existing test are passing