### PR TITLE
test: add unit tests for Device, Command, Collection, and String extensions

### DIFF
--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		162A369BC040E62A74C782D1 /* CollectionGetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912D7A2027F3DDA86839E7AE /* CollectionGetTests.swift */; };
+		16B53AB50DDD40DC4880CCB8 /* DeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470EFF3B34FB31AC5A22B024 /* DeviceTests.swift */; };
+		2549AC06811CB09AF7D5A4DF /* CommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E9205F1463934FDB7D92FF /* CommandTests.swift */; };
 		4AFACC742AD730BE00EC369F /* SubMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFACC732AD730BE00EC369F /* SubMenuItem.swift */; };
 		4AFACC762AD73D7900EC369F /* NSMenuItem+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFACC752AD73D7900EC369F /* NSMenuItem+ConvenienceInit.swift */; };
 		4AFACC782AD74E9000EC369F /* DeviceListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFACC772AD74E9000EC369F /* DeviceListSection.swift */; };
@@ -108,6 +111,7 @@
 		76F2A9172991B7B6002D4EF6 /* ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2A9162991B7B6002D4EF6 /* ViewModifiers.swift */; };
 		76FCABAB29B390D5003BBF9A /* Collection+get.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FCABAA29B390D5003BBF9A /* Collection+get.swift */; };
 		7D4142B4F3AF1D150D9222BD /* DeviceFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F78DD26087D5448AAB2CC3B /* DeviceFamily.swift */; };
+		7D850183B2E53A3E4F17994A /* StringMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9C6AA804E851167EA01B17 /* StringMatchTests.swift */; };
 		9B225A9C2C7E360D002620BA /* DeviceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B225A9B2C7E360D002620BA /* DeviceType.swift */; };
 /* End PBXBuildFile section */
 
@@ -122,6 +126,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		470EFF3B34FB31AC5A22B024 /* DeviceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceTests.swift; sourceTree = "<group>"; };
 		4AFACC732AD730BE00EC369F /* SubMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubMenuItem.swift; sourceTree = "<group>"; };
 		4AFACC752AD73D7900EC369F /* NSMenuItem+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenuItem+ConvenienceInit.swift"; sourceTree = "<group>"; };
 		4AFACC772AD74E9000EC369F /* DeviceListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceListSection.swift; sourceTree = "<group>"; };
@@ -131,6 +136,8 @@
 		551B88292B1385E900B8D325 /* Terminal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Terminal.swift; sourceTree = "<group>"; };
 		55CDB0772B1B6D24002418D7 /* TerminalApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalApps.swift; sourceTree = "<group>"; };
 		5F78DD26087D5448AAB2CC3B /* DeviceFamily.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceFamily.swift; sourceTree = "<group>"; };
+		63E9205F1463934FDB7D92FF /* CommandTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommandTests.swift; sourceTree = "<group>"; };
+		6A9C6AA804E851167EA01B17 /* StringMatchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringMatchTests.swift; sourceTree = "<group>"; };
 		760554A22C085BEA001607FE /* Thread+Asserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thread+Asserts.swift"; sourceTree = "<group>"; };
 		76059BF42AD4361C0008D38B /* SetupPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupPreferences.swift; sourceTree = "<group>"; };
 		76059BF62AD449DC0008D38B /* OnboardingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingHeader.swift; sourceTree = "<group>"; };
@@ -219,6 +226,7 @@
 		76F2A913299050F9002D4EF6 /* UserDefaults+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Configuration.swift"; sourceTree = "<group>"; };
 		76F2A9162991B7B6002D4EF6 /* ViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModifiers.swift; sourceTree = "<group>"; };
 		76FCABAA29B390D5003BBF9A /* Collection+get.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+get.swift"; sourceTree = "<group>"; };
+		912D7A2027F3DDA86839E7AE /* CollectionGetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionGetTests.swift; sourceTree = "<group>"; };
 		9B225A9B2C7E360D002620BA /* DeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -463,6 +471,10 @@
 				76BF0AF32C90A74E003BE568 /* AppleUtilsTests.swift */,
 				76BF0AF52C90AB03003BE568 /* DeviceDiscoveryTests.swift */,
 				76BF0AF72C90ACF2003BE568 /* ActionFactoryTests.swift */,
+				470EFF3B34FB31AC5A22B024 /* DeviceTests.swift */,
+				6A9C6AA804E851167EA01B17 /* StringMatchTests.swift */,
+				912D7A2027F3DDA86839E7AE /* CollectionGetTests.swift */,
+				63E9205F1463934FDB7D92FF /* CommandTests.swift */,
 			);
 			path = MiniSimTests;
 			sourceTree = "<group>";
@@ -741,6 +753,10 @@
 				76B70F7E2B0D361A009D87A4 /* UserDefaultsTests.swift in Sources */,
 				760DEACE2B0DFB6600253576 /* ShellStub.swift in Sources */,
 				76B70F822B0D50FE009D87A4 /* ADBTests.swift in Sources */,
+				16B53AB50DDD40DC4880CCB8 /* DeviceTests.swift in Sources */,
+				7D850183B2E53A3E4F17994A /* StringMatchTests.swift in Sources */,
+				162A369BC040E62A74C782D1 /* CollectionGetTests.swift in Sources */,
+				2549AC06811CB09AF7D5A4DF /* CommandTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MiniSimTests/CollectionGetTests.swift
+++ b/MiniSimTests/CollectionGetTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+@testable import MiniSim
+
+final class CollectionGetTests: XCTestCase {
+  func testGetAtValidIndex() {
+    let array = ["a", "b", "c"]
+
+    XCTAssertEqual(array.get(at: 0), "a")
+    XCTAssertEqual(array.get(at: 1), "b")
+    XCTAssertEqual(array.get(at: 2), "c")
+  }
+
+  func testGetAtInvalidIndex() {
+    let array = ["a", "b", "c"]
+
+    XCTAssertNil(array.get(at: 3))
+    XCTAssertNil(array.get(at: 100))
+  }
+
+  func testGetOnEmptyCollection() {
+    let array: [String] = []
+
+    XCTAssertNil(array.get(at: 0))
+  }
+
+  func testGetWithDifferentTypes() {
+    let intArray = [1, 2, 3]
+    XCTAssertEqual(intArray.get(at: 1), 2)
+
+    let deviceArray = [
+      Device(name: "iPhone", identifier: "uuid1", platform: .ios, type: .virtual),
+      Device(name: "Pixel", identifier: "uuid2", platform: .android, type: .virtual)
+    ]
+    XCTAssertEqual(deviceArray.get(at: 0)?.name, "iPhone")
+    XCTAssertEqual(deviceArray.get(at: 1)?.platform, .android)
+    XCTAssertNil(deviceArray.get(at: 2))
+  }
+
+  func testGetOnDictionary() {
+    let dict = ["a": 1, "b": 2]
+    let keys = Array(dict.keys).sorted()
+
+    XCTAssertNotNil(keys.get(at: 0))
+    XCTAssertNil(keys.get(at: 10))
+  }
+}

--- a/MiniSimTests/CommandTests.swift
+++ b/MiniSimTests/CommandTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+@testable import MiniSim
+
+final class CommandTests: XCTestCase {
+  func testEncodingDecoding() throws {
+    let command = Command(
+      name: "Test Command",
+      command: "adb devices",
+      icon: "terminal",
+      platform: .android,
+      needBootedDevice: true,
+      bootsDevice: false,
+      tag: 42
+    )
+
+    let encoded = try JSONEncoder().encode(command)
+    let decoded = try JSONDecoder().decode(Command.self, from: encoded)
+
+    XCTAssertEqual(decoded.name, command.name)
+    XCTAssertEqual(decoded.command, command.command)
+    XCTAssertEqual(decoded.icon, command.icon)
+    XCTAssertEqual(decoded.platform, command.platform)
+    XCTAssertEqual(decoded.needBootedDevice, command.needBootedDevice)
+    XCTAssertEqual(decoded.bootsDevice, command.bootsDevice)
+    XCTAssertEqual(decoded.tag, command.tag)
+  }
+
+  func testDecodingOptionalFieldsNil() throws {
+    let json = """
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "Test",
+      "command": "echo test",
+      "icon": "star",
+      "platform": "ios",
+      "needBootedDevice": false
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(Command.self, from: data)
+
+    XCTAssertEqual(decoded.name, "Test")
+    XCTAssertEqual(decoded.platform, .ios)
+    XCTAssertNil(decoded.bootsDevice)
+    XCTAssertNil(decoded.tag)
+  }
+
+  func testDecodingOptionalFieldsPresent() throws {
+    let json = """
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "Test",
+      "command": "echo test",
+      "icon": "star",
+      "platform": "android",
+      "needBootedDevice": true,
+      "bootsDevice": true,
+      "tag": 99
+    }
+    """
+
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(Command.self, from: data)
+
+    XCTAssertEqual(decoded.bootsDevice, true)
+    XCTAssertEqual(decoded.tag, 99)
+  }
+
+  func testCommandHashable() {
+    let command1 = Command(
+      name: "Test",
+      command: "echo",
+      icon: "star",
+      platform: .ios,
+      needBootedDevice: false
+    )
+
+    let command2 = Command(
+      name: "Test",
+      command: "echo",
+      icon: "star",
+      platform: .ios,
+      needBootedDevice: false
+    )
+
+    // Different UUIDs, so not equal
+    XCTAssertNotEqual(command1, command2)
+
+    // Same command in set should work
+    var commandSet: Set<Command> = []
+    commandSet.insert(command1)
+    commandSet.insert(command2)
+    XCTAssertEqual(commandSet.count, 2)
+  }
+
+  func testCommandIdentifiable() {
+    let command = Command(
+      name: "Test",
+      command: "echo",
+      icon: "star",
+      platform: .ios,
+      needBootedDevice: false
+    )
+
+    XCTAssertNotNil(command.id)
+  }
+}

--- a/MiniSimTests/DeviceTests.swift
+++ b/MiniSimTests/DeviceTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import MiniSim
+
+final class DeviceTests: XCTestCase {
+  func testDisplayNameIOSWithVersion() {
+    let device = Device(
+      name: "iPhone 15 Pro",
+      version: "iOS 17.5",
+      identifier: "test-uuid",
+      booted: false,
+      platform: .ios,
+      type: .virtual
+    )
+
+    XCTAssertEqual(device.displayName, "iPhone 15 Pro - (iOS 17.5)")
+  }
+
+  func testDisplayNameIOSWithoutVersion() {
+    let device = Device(
+      name: "iPhone 15 Pro",
+      version: nil,
+      identifier: "test-uuid",
+      booted: false,
+      platform: .ios,
+      type: .virtual
+    )
+
+    XCTAssertEqual(device.displayName, "iPhone 15 Pro")
+  }
+
+  func testDisplayNameAndroid() {
+    let device = Device(
+      name: "Pixel_5_API_33",
+      version: "13",
+      identifier: "emulator-5554",
+      booted: true,
+      platform: .android,
+      type: .virtual
+    )
+
+    XCTAssertEqual(device.displayName, "Pixel_5_API_33")
+  }
+
+  func testEncodingDecoding() throws {
+    let device = Device(
+      name: "iPhone 15 Pro",
+      version: "iOS 17.5",
+      identifier: "test-uuid",
+      booted: true,
+      platform: .ios,
+      type: .virtual
+    )
+
+    let encoded = try JSONEncoder().encode(device)
+    let decoded = try JSONDecoder().decode(Device.self, from: encoded)
+
+    XCTAssertEqual(decoded.name, device.name)
+    XCTAssertEqual(decoded.version, device.version)
+    XCTAssertEqual(decoded.identifier, device.identifier)
+    XCTAssertEqual(decoded.booted, device.booted)
+    XCTAssertEqual(decoded.platform, device.platform)
+    XCTAssertEqual(decoded.type, device.type)
+  }
+
+  func testEncodingIncludesDisplayName() throws {
+    let device = Device(
+      name: "iPhone 15",
+      version: "iOS 17.5",
+      identifier: "uuid",
+      booted: false,
+      platform: .ios,
+      type: .virtual
+    )
+
+    let encoded = try JSONEncoder().encode(device)
+    let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+
+    XCTAssertEqual(json?["displayName"] as? String, "iPhone 15 - (iOS 17.5)")
+  }
+}

--- a/MiniSimTests/StringMatchTests.swift
+++ b/MiniSimTests/StringMatchTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import MiniSim
+
+final class StringMatchTests: XCTestCase {
+  func testMatchWithValidPattern() {
+    let input = "iPhone 15 Pro"
+    let matches = input.match("iPhone")
+
+    XCTAssertEqual(matches.count, 1)
+    XCTAssertEqual(matches.first?.first, "iPhone")
+  }
+
+  func testMatchWithNoMatch() {
+    let input = "iPhone 15 Pro"
+    let matches = input.match("Android")
+
+    XCTAssertTrue(matches.isEmpty)
+  }
+
+  func testMatchWithMultipleMatches() {
+    let input = "abc123def456ghi789"
+    let matches = input.match("[0-9]+")
+
+    XCTAssertEqual(matches.count, 3)
+    XCTAssertEqual(matches[0].first, "123")
+    XCTAssertEqual(matches[1].first, "456")
+    XCTAssertEqual(matches[2].first, "789")
+  }
+
+  func testMatchWithCaptureGroups() {
+    let input = "emulator-5554"
+    let matches = input.match("(emulator)-([0-9]+)")
+
+    XCTAssertEqual(matches.count, 1)
+    XCTAssertEqual(matches[0][0], "emulator-5554")
+    XCTAssertEqual(matches[0][1], "emulator")
+    XCTAssertEqual(matches[0][2], "5554")
+  }
+
+  func testMatchWithEmptyString() {
+    let input = ""
+    let matches = input.match("[a-z]+")
+
+    XCTAssertTrue(matches.isEmpty)
+  }
+
+  func testMatchUUIDPattern() {
+    let input = "iPhone 15 (957C8A2F-4C12-4732-A4E9-37F8FDD35E3B) (Booted)"
+    let matches = input.match("[A-F0-9-]{36}")
+
+    XCTAssertEqual(matches.count, 1)
+    XCTAssertEqual(matches.first?.first, "957C8A2F-4C12-4732-A4E9-37F8FDD35E3B")
+  }
+
+  func testMatchEmulatorIdPattern() {
+    let input = "emulator-5554          device"
+    let matches = input.match("^emulator-[0-9]+")
+
+    XCTAssertEqual(matches.count, 1)
+    XCTAssertEqual(matches.first?.first, "emulator-5554")
+  }
+}


### PR DESCRIPTION
## Summary:

Improve test coverage by adding unit tests for core model types and utility extensions that were previously untested.

## Changelog:

- Add `DeviceTests` - tests `displayName` computed property for iOS/Android, encoding/decoding
- Add `CommandTests` - tests Codable conformance, optional fields, Hashable/Identifiable
- Add `CollectionGetTests` - tests safe index access for various collection types
- Add `StringMatchTests` - tests regex matching with capture groups, edge cases

## Test Plan:

```bash
xcodebuild test -scheme MiniSim -destination 'platform=macOS'
```

All 4 new test files pass. Build verified with `xcodebuild build`.