### PR TITLE
Added [Local Files] submenu section with [Upload...] submenu to upload file/folder to simulator/emulator/device

### DIFF
--- a/MiniSim.xcodeproj/project.pbxproj
+++ b/MiniSim.xcodeproj/project.pbxproj
@@ -112,6 +112,9 @@
 		76FCABAB29B390D5003BBF9A /* Collection+get.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FCABAA29B390D5003BBF9A /* Collection+get.swift */; };
 		7D4142B4F3AF1D150D9222BD /* DeviceFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F78DD26087D5448AAB2CC3B /* DeviceFamily.swift */; };
 		7D850183B2E53A3E4F17994A /* StringMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9C6AA804E851167EA01B17 /* StringMatchTests.swift */; };
+		7A9C0F1B2D3E4A5B6C7D8EA1 /* UploadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9C0F1B2D3E4A5B6C7D8E9F /* UploadHelpers.swift */; };
+		7A9C0F1B2D3E4A5B6C7D8EA3 /* UploadHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9C0F1B2D3E4A5B6C7D8EA2 /* UploadHelpersTests.swift */; };
+		7B1E9F672D3F4B3C9A0D1B22 /* ShellEscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1E9F662D3F4B3C9A0D1B21 /* ShellEscapingTests.swift */; };
 		9B225A9C2C7E360D002620BA /* DeviceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B225A9B2C7E360D002620BA /* DeviceType.swift */; };
 /* End PBXBuildFile section */
 
@@ -226,6 +229,9 @@
 		76F2A913299050F9002D4EF6 /* UserDefaults+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Configuration.swift"; sourceTree = "<group>"; };
 		76F2A9162991B7B6002D4EF6 /* ViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModifiers.swift; sourceTree = "<group>"; };
 		76FCABAA29B390D5003BBF9A /* Collection+get.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+get.swift"; sourceTree = "<group>"; };
+		7A9C0F1B2D3E4A5B6C7D8E9F /* UploadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadHelpers.swift; sourceTree = "<group>"; };
+		7A9C0F1B2D3E4A5B6C7D8EA2 /* UploadHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadHelpersTests.swift; sourceTree = "<group>"; };
+		7B1E9F662D3F4B3C9A0D1B21 /* ShellEscapingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEscapingTests.swift; sourceTree = "<group>"; };
 		912D7A2027F3DDA86839E7AE /* CollectionGetTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionGetTests.swift; sourceTree = "<group>"; };
 		9B225A9B2C7E360D002620BA /* DeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -359,6 +365,7 @@
 				76BF0ADE2C8E01B3003BE568 /* CustomCommandService.swift */,
 				76BF0AE02C8E027D003BE568 /* DeviceConstants.swift */,
 				76BF0AE52C8E0F83003BE568 /* Actions.swift */,
+				7A9C0F1B2D3E4A5B6C7D8E9F /* UploadHelpers.swift */,
 				76BF0AE72C8E1077003BE568 /* ActionFactory.swift */,
 				76BF0AEF2C9061E8003BE568 /* DeviceDiscoveryService.swift */,
 				76BF0AF12C907032003BE568 /* DeviceServiceFactory.swift */,
@@ -471,6 +478,8 @@
 				76BF0AF32C90A74E003BE568 /* AppleUtilsTests.swift */,
 				76BF0AF52C90AB03003BE568 /* DeviceDiscoveryTests.swift */,
 				76BF0AF72C90ACF2003BE568 /* ActionFactoryTests.swift */,
+				7A9C0F1B2D3E4A5B6C7D8EA2 /* UploadHelpersTests.swift */,
+				7B1E9F662D3F4B3C9A0D1B21 /* ShellEscapingTests.swift */,
 				470EFF3B34FB31AC5A22B024 /* DeviceTests.swift */,
 				6A9C6AA804E851167EA01B17 /* StringMatchTests.swift */,
 				912D7A2027F3DDA86839E7AE /* CollectionGetTests.swift */,
@@ -694,6 +703,7 @@
 				76BF0AF22C907033003BE568 /* DeviceServiceFactory.swift in Sources */,
 				764BA3EB2A5AD43F003A78AF /* LaunchDeviceCommand.swift in Sources */,
 				76BF0AE62C8E0F83003BE568 /* Actions.swift in Sources */,
+				7A9C0F1B2D3E4A5B6C7D8EA1 /* UploadHelpers.swift in Sources */,
 				7630B2732986C68000D8B57D /* PaneIdentifier.swift in Sources */,
 				7630B2662985C44A00D8B57D /* Preferences.swift in Sources */,
 				7625140B2992B46D0060A225 /* Pasteboard+utils.swift in Sources */,
@@ -750,6 +760,8 @@
 				76BF0AE32C8E041C003BE568 /* CustomCommandServiceTests.swift in Sources */,
 				76BF0AF42C90A74E003BE568 /* AppleUtilsTests.swift in Sources */,
 				76BF0AF82C90ACF2003BE568 /* ActionFactoryTests.swift in Sources */,
+				7A9C0F1B2D3E4A5B6C7D8EA3 /* UploadHelpersTests.swift in Sources */,
+				7B1E9F672D3F4B3C9A0D1B22 /* ShellEscapingTests.swift in Sources */,
 				76B70F7E2B0D361A009D87A4 /* UserDefaultsTests.swift in Sources */,
 				760DEACE2B0DFB6600253576 /* ShellStub.swift in Sources */,
 				76B70F822B0D50FE009D87A4 /* ADBTests.swift in Sources */,

--- a/MiniSim/Extensions/NSAlert+showError.swift
+++ b/MiniSim/Extensions/NSAlert+showError.swift
@@ -33,4 +33,31 @@ extension NSAlert {
         alert.addButton(withTitle: "Cancel")
         return alert.runModal() == .alertFirstButtonReturn
     }
+
+    static func showWarningDialog(
+        title: String,
+        message: String,
+        primaryButton: String,
+        secondaryButton: String?
+    ) -> NSApplication.ModalResponse {
+        let showAlert: () -> NSApplication.ModalResponse = {
+            let alert = self.init()
+            alert.messageText = title
+            alert.informativeText = message
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: primaryButton)
+            if let secondaryButton {
+                alert.addButton(withTitle: secondaryButton)
+            }
+            return alert.runModal()
+        }
+
+        if Thread.isMainThread {
+            return showAlert()
+        }
+
+        return DispatchQueue.main.sync {
+            showAlert()
+        }
+    }
 }

--- a/MiniSim/Extensions/NSMenuItem+ConvenienceInit.swift
+++ b/MiniSim/Extensions/NSMenuItem+ConvenienceInit.swift
@@ -24,7 +24,7 @@ extension NSMenuItem {
         self.tag = menuItem.tag
         self.image = menuItem.image
         self.title = menuItem.title
-        self.toolTip = menuItem.title
+        self.toolTip = menuItem.toolTip ?? menuItem.title
         self.target = target
         self.action = action
     }

--- a/MiniSim/Menu.swift
+++ b/MiniSim/Menu.swift
@@ -265,25 +265,63 @@ class Menu: NSMenu {
         isDeviceBooted: Bool,
         callback: Selector
     ) -> [NSMenuItem] {
-        subMenuItems.compactMap { item in
+        var menuItems: [NSMenuItem] = []
+
+        subMenuItems.forEach { item in
             if item is SubMenuItems.Separator {
-                return NSMenuItem.separator()
+                menuItems.append(NSMenuItem.separator())
+                return
+            }
+
+            if let item = item as? SubMenuSectionItem {
+                if item.needBootedDevice && !isDeviceBooted {
+                    return
+                }
+                let menuItem = NSMenuItem(title: item.title, action: nil, keyEquivalent: "")
+                menuItem.isEnabled = false
+                menuItems.append(menuItem)
+                return
             }
 
             if let item = item as? SubMenuActionItem {
                 if item.needBootedDevice && !isDeviceBooted {
-                    return nil
+                    return
                 }
 
                 if item.bootsDevice && isDeviceBooted {
-                    return nil
+                    return
                 }
 
-                return NSMenuItem(menuItem: item, target: self, action: callback)
+                menuItems.append(NSMenuItem(menuItem: item, target: self, action: callback))
+                return
             }
-
-            return nil
         }
+
+        return normalizeSeparators(menuItems)
+    }
+
+    private func normalizeSeparators(_ items: [NSMenuItem]) -> [NSMenuItem] {
+        var normalized: [NSMenuItem] = []
+        var previousWasSeparator = true
+
+        for item in items {
+            if item.isSeparatorItem {
+                if previousWasSeparator {
+                    continue
+                }
+                normalized.append(item)
+                previousWasSeparator = true
+            } else {
+                normalized.append(item)
+                previousWasSeparator = false
+            }
+        }
+
+        while normalized.last?.isSeparatorItem == true {
+            normalized.removeLast()
+        }
+
+        return normalized
     }
 
     func createCustomCommandsMenu(for platform: Platform, isDeviceBooted: Bool, callback: Selector) -> [NSMenuItem] {

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -28,6 +28,7 @@ enum SubMenuItems {
         case paste
         case delete
         case logcat
+        case upload
         case customCommand = 200
     }
 
@@ -110,6 +111,17 @@ enum SubMenuItems {
         )
     }
 
+    struct Upload: SubMenuActionItem {
+        let title = NSLocalizedString("Upload to Downloads...", comment: "")
+        let tag = Tags.upload.rawValue
+        let bootsDevice = false
+        let needBootedDevice = true
+        let image = NSImage(
+            systemSymbolName: "tray.and.arrow.up",
+            accessibilityDescription: "Upload"
+        )
+    }
+
     struct Delete: SubMenuActionItem {
         let title = NSLocalizedString("Delete simulator", comment: "")
         let tag = Tags.delete.rawValue
@@ -184,6 +196,7 @@ extension SubMenuItems {
         NoAudio(),
         ToggleA11y(),
         Paste(),
+        Upload(),
         DeleteEmulator(),
         LaunchLogCat()
       ]

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -182,6 +182,7 @@ extension SubMenuItems {
 
         ToggleA11y(),
         Paste(),
+        Upload(),
         LaunchLogCat()
       ]
 

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -18,6 +18,11 @@ protocol SubMenuActionItem: SubMenuItem {
     var image: NSImage? { get }
 }
 
+protocol SubMenuSectionItem: SubMenuItem {
+    var title: String { get }
+    var needBootedDevice: Bool { get }
+}
+
 enum SubMenuItems {
     enum Tags: Int, CaseIterable {
         case copyName = 100
@@ -29,10 +34,16 @@ enum SubMenuItems {
         case delete
         case logcat
         case upload
+        case localFiles
         case customCommand = 200
     }
 
     struct Separator: SubMenuItem { }
+
+    struct SectionTitle: SubMenuSectionItem {
+        let title: String
+        let needBootedDevice: Bool
+    }
 
     struct CopyName: SubMenuActionItem {
         let title = NSLocalizedString("Copy name", comment: "")
@@ -122,6 +133,28 @@ enum SubMenuItems {
         )
     }
 
+    struct UploadToFiles: SubMenuActionItem {
+        let title = NSLocalizedString("Upload...", comment: "")
+        let tag = Tags.upload.rawValue
+        let bootsDevice = false
+        let needBootedDevice = true
+        let image = NSImage(
+            systemSymbolName: "tray.and.arrow.up",
+            accessibilityDescription: "Upload"
+        )
+    }
+
+    struct LocalFiles: SubMenuActionItem {
+        let title = NSLocalizedString("Open in Finder", comment: "")
+        let tag = Tags.localFiles.rawValue
+        let bootsDevice = false
+        let needBootedDevice = true
+        let image = NSImage(
+            systemSymbolName: "folder",
+            accessibilityDescription: "Local Files"
+        )
+    }
+
     struct Delete: SubMenuActionItem {
         let title = NSLocalizedString("Delete simulator", comment: "")
         let tag = Tags.delete.rawValue
@@ -168,6 +201,15 @@ extension SubMenuItems {
       return [
         CopyName(),
         CopyUDID(),
+
+        Separator(),
+
+        SectionTitle(
+            title: NSLocalizedString("Local Files", comment: ""),
+            needBootedDevice: true
+        ),
+        UploadToFiles(),
+        LocalFiles(),
 
         Separator(),
 

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -198,8 +198,11 @@ extension SubMenuItems {
         ToggleA11y(),
         Paste(),
         Upload(),
-        DeleteEmulator(),
-        LaunchLogCat()
+        LaunchLogCat(),
+
+        Separator(),
+
+        DeleteEmulator()
       ]
     }
   }

--- a/MiniSim/MenuItems/SubMenuItem.swift
+++ b/MiniSim/MenuItems/SubMenuItem.swift
@@ -16,6 +16,13 @@ protocol SubMenuActionItem: SubMenuItem {
     var needBootedDevice: Bool { get }
     var bootsDevice: Bool { get }
     var image: NSImage? { get }
+    var toolTip: String? { get }
+}
+
+extension SubMenuActionItem {
+    var toolTip: String? {
+        nil
+    }
 }
 
 protocol SubMenuSectionItem: SubMenuItem {
@@ -123,13 +130,17 @@ enum SubMenuItems {
     }
 
     struct Upload: SubMenuActionItem {
-        let title = NSLocalizedString("Upload to Downloads...", comment: "")
+        let title = NSLocalizedString("Upload...", comment: "")
         let tag = Tags.upload.rawValue
         let bootsDevice = false
         let needBootedDevice = true
         let image = NSImage(
             systemSymbolName: "tray.and.arrow.up",
             accessibilityDescription: "Upload"
+        )
+        let toolTip: String? = NSLocalizedString(
+            "Upload file/folder to internal storage Downloads folder",
+            comment: ""
         )
     }
 
@@ -224,8 +235,15 @@ extension SubMenuItems {
 
         ToggleA11y(),
         Paste(),
-        Upload(),
-        LaunchLogCat()
+        LaunchLogCat(),
+
+        Separator(),
+
+        SectionTitle(
+            title: NSLocalizedString("Local Files", comment: ""),
+            needBootedDevice: true
+        ),
+        Upload()
       ]
 
     case (.android, .virtual):
@@ -239,8 +257,15 @@ extension SubMenuItems {
         NoAudio(),
         ToggleA11y(),
         Paste(),
-        Upload(),
         LaunchLogCat(),
+
+        Separator(),
+
+        SectionTitle(
+            title: NSLocalizedString("Local Files", comment: ""),
+            needBootedDevice: true
+        ),
+        Upload(),
 
         Separator(),
 

--- a/MiniSim/Service/ActionFactory.swift
+++ b/MiniSim/Service/ActionFactory.swift
@@ -20,6 +20,8 @@ class AndroidActionFactory: ActionFactory {
       return ToggleA11yCommand(device: device)
     case .paste:
       return PasteClipboardAction(device: device)
+    case .upload:
+      return UploadToDownloadsAction(device: device)
     case .delete:
       return DeleteAction(device: device, skipConfirmation: skipConfirmation)
     case .customCommand:

--- a/MiniSim/Service/ActionFactory.swift
+++ b/MiniSim/Service/ActionFactory.swift
@@ -22,6 +22,8 @@ class AndroidActionFactory: ActionFactory {
       return PasteClipboardAction(device: device)
     case .upload:
       return UploadToDownloadsAction(device: device)
+    case .localFiles:
+      return UnsupportedAction(message: "Local Files is only available for iOS simulators.")
     case .delete:
       return DeleteAction(device: device, skipConfirmation: skipConfirmation)
     case .customCommand:
@@ -39,6 +41,10 @@ class IOSActionFactory: ActionFactory {
       return CopyNameAction(device: device)
     case .copyID:
       return CopyIDAction(device: device)
+    case .upload:
+      return UploadToSimulatorFilesAction(device: device)
+    case .localFiles:
+      return OpenSimulatorFilesAction(device: device)
     case .customCommand:
       return CustomCommandAction(device: device, itemName: itemName)
     case .coldBoot:

--- a/MiniSim/Service/Actions.swift
+++ b/MiniSim/Service/Actions.swift
@@ -82,6 +82,26 @@ class CustomCommandAction: Action {
   }
 }
 
+class UnsupportedAction: Action {
+  private let message: String
+
+  init(message: String) {
+    self.message = message
+  }
+
+  func execute() throws {
+    throw UnsupportedActionError(message: message)
+  }
+}
+
+struct UnsupportedActionError: Error, LocalizedError {
+  let message: String
+
+  var errorDescription: String? {
+    message
+  }
+}
+
 // MARK: Android Actions
 
 class PasteClipboardAction: Action {
@@ -261,5 +281,266 @@ class ToggleA11yCommand: Action {
       return
     }
     ADB.toggleAccesibility(deviceId: deviceId)
+  }
+}
+
+// MARK: iOS Simulator Files Actions
+
+enum SimulatorFilesError: Error {
+  case unsupportedDevice
+  case missingIdentifier
+  case baseDirectoryMissing
+  case storageNotFound
+}
+
+extension SimulatorFilesError: LocalizedError {
+  var errorDescription: String? {
+    switch self {
+    case .unsupportedDevice:
+      return NSLocalizedString("This action is only available for iOS simulators.", comment: "")
+    case .missingIdentifier:
+      return NSLocalizedString("Simulator identifier is missing.", comment: "")
+    case .baseDirectoryMissing:
+      return NSLocalizedString("Simulator data folder not found. Boot the simulator and try again.", comment: "")
+    case .storageNotFound:
+      return NSLocalizedString(
+        "File Provider Storage folder not found. Boot the simulator and open the Files app once, then try again.",
+        comment: ""
+      )
+    }
+  }
+}
+
+struct SimulatorFileProviderStorage {
+  static func url(for device: Device) throws -> URL {
+    guard device.platform == .ios, device.type == .virtual else {
+      throw SimulatorFilesError.unsupportedDevice
+    }
+    guard let identifier = device.identifier, !identifier.isEmpty else {
+      throw SimulatorFilesError.missingIdentifier
+    }
+
+    let baseURL = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/Developer/CoreSimulator/Devices", isDirectory: true)
+      .appendingPathComponent(identifier, isDirectory: true)
+      .appendingPathComponent("data/Containers/Shared/AppGroup", isDirectory: true)
+
+    guard FileManager.default.fileExists(atPath: baseURL.path) else {
+      throw SimulatorFilesError.baseDirectoryMissing
+    }
+
+    let groupUrls = try FileManager.default.contentsOfDirectory(
+      at: baseURL,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    )
+
+    let candidates = groupUrls
+      .sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+      .compactMap { groupURL -> (url: URL, identifier: String?)? in
+        let isDirectory = (try? groupURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        guard isDirectory else {
+          return nil
+        }
+
+        let storageURL = groupURL.appendingPathComponent("File Provider Storage", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: storageURL.path) else {
+          return nil
+        }
+
+        let metadataURL = groupURL.appendingPathComponent(
+          ".com.apple.mobile_container_manager.metadata.plist",
+          isDirectory: false
+        )
+        let identifier = metadataIdentifier(from: metadataURL)
+        return (storageURL, identifier)
+      }
+
+    if let preferred = candidates.first(where: { $0.identifier == "group.com.apple.FileProvider.LocalStorage" }) {
+      return preferred.url
+    }
+
+    if let fileProvider = candidates.first(where: { ($0.identifier ?? "").contains("FileProvider") }) {
+      return fileProvider.url
+    }
+
+    if let fallback = candidates.first {
+      return fallback.url
+    }
+
+    throw SimulatorFilesError.storageNotFound
+  }
+
+  private static func metadataIdentifier(from metadataURL: URL) -> String? {
+    guard let data = try? Data(contentsOf: metadataURL),
+          let plist = try? PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: nil
+          ) as? [String: Any] else {
+      return nil
+    }
+    return plist["MCMMetadataIdentifier"] as? String
+  }
+}
+
+class UploadToSimulatorFilesAction: Action {
+  let device: Device
+  private let destinationLabel = "Local Files"
+
+  init(device: Device) {
+    self.device = device
+  }
+
+  func execute() throws {
+    let selectedUrls = pickUploadItems()
+    let filteredUrls = selectedUrls.filter { $0.lastPathComponent != ".DS_Store" }
+    guard !filteredUrls.isEmpty else {
+      return
+    }
+
+    let storageURL = try SimulatorFileProviderStorage.url(for: device)
+
+    for url in filteredUrls {
+      try uploadItem(url: url, destinationURL: storageURL)
+    }
+
+    let uploadedLabel: String
+    if filteredUrls.count == 1 {
+      uploadedLabel = filteredUrls[0].lastPathComponent
+    } else {
+      uploadedLabel = "\(filteredUrls.count) items"
+    }
+
+    MiniSim.showSuccessMessage(
+      title: "Upload complete",
+      message: "Uploaded \(uploadedLabel) to \(destinationLabel)."
+    )
+  }
+
+  private func uploadItem(url: URL, destinationURL: URL) throws {
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+    guard exists else {
+      return
+    }
+
+    if isDirectory.boolValue {
+      try uploadDirectory(url: url, destinationURL: destinationURL)
+    } else {
+      let fileDestination = destinationURL.appendingPathComponent(url.lastPathComponent, isDirectory: false)
+      try copyItemReplacingIfNeeded(from: url, to: fileDestination)
+    }
+  }
+
+  private func uploadDirectory(url: URL, destinationURL: URL) throws {
+    let baseDestination = destinationURL.appendingPathComponent(url.lastPathComponent, isDirectory: true)
+    let rootComponents = url.pathComponents
+    let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
+
+    try FileManager.default.createDirectory(
+      at: baseDestination,
+      withIntermediateDirectories: true,
+      attributes: nil
+    )
+
+    guard let enumerator = FileManager.default.enumerator(
+      at: url,
+      includingPropertiesForKeys: Array(resourceKeys),
+      options: [],
+      errorHandler: { _, _ in true }
+    ) else {
+      return
+    }
+
+    for case let fileUrl as URL in enumerator {
+      if fileUrl.lastPathComponent == ".DS_Store" {
+        continue
+      }
+
+      let resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
+      guard resourceValues.isRegularFile == true else {
+        continue
+      }
+
+      let fileComponents = fileUrl.pathComponents
+      guard fileComponents.count >= rootComponents.count else {
+        continue
+      }
+
+      let relativeComponents = Array(fileComponents.dropFirst(rootComponents.count))
+      guard !relativeComponents.isEmpty else {
+        continue
+      }
+
+      let relativeDirComponents = Array(relativeComponents.dropLast())
+      let destinationDir = relativeDirComponents.reduce(baseDestination) { partial, component in
+        partial.appendingPathComponent(component, isDirectory: true)
+      }
+
+      try FileManager.default.createDirectory(
+        at: destinationDir,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+
+      let destinationFile = destinationDir.appendingPathComponent(fileUrl.lastPathComponent, isDirectory: false)
+      try copyItemReplacingIfNeeded(from: fileUrl, to: destinationFile)
+    }
+  }
+
+  private func copyItemReplacingIfNeeded(from sourceURL: URL, to destinationURL: URL) throws {
+    if FileManager.default.fileExists(atPath: destinationURL.path) {
+      try FileManager.default.removeItem(at: destinationURL)
+    }
+    try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+  }
+
+  private func pickUploadItems() -> [URL] {
+    let openPanelAction: () -> [URL] = {
+      let panel = NSOpenPanel()
+      NSApp.activate(ignoringOtherApps: true)
+      panel.allowsMultipleSelection = true
+      panel.canChooseFiles = true
+      panel.canChooseDirectories = true
+      panel.prompt = "Upload"
+      panel.message = "Choose files or folders to upload to \(self.destinationLabel)."
+      let response = panel.runModal()
+      return response == .OK ? panel.urls : []
+    }
+
+    if Thread.isMainThread {
+      return openPanelAction()
+    }
+
+    return DispatchQueue.main.sync {
+      openPanelAction()
+    }
+  }
+}
+
+class OpenSimulatorFilesAction: Action {
+  let device: Device
+
+  init(device: Device) {
+    self.device = device
+  }
+
+  func execute() throws {
+    let storageURL = try SimulatorFileProviderStorage.url(for: device)
+
+    let openAction = {
+      if !NSWorkspace.shared.open(storageURL) {
+        NSWorkspace.shared.activateFileViewerSelecting([storageURL])
+      }
+    }
+
+    if Thread.isMainThread {
+      openAction()
+    } else {
+      DispatchQueue.main.sync {
+        openAction()
+      }
+    }
   }
 }

--- a/MiniSim/Service/Actions.swift
+++ b/MiniSim/Service/Actions.swift
@@ -100,6 +100,119 @@ class PasteClipboardAction: Action {
   }
 }
 
+class UploadToDownloadsAction: Action {
+  let device: Device
+  private let destinationPath = "/sdcard/Download"
+
+  init(device: Device) {
+    self.device = device
+  }
+
+  func execute() throws {
+    let selectedUrls = pickUploadItems()
+    let filteredUrls = selectedUrls.filter { $0.lastPathComponent != ".DS_Store" }
+    guard !filteredUrls.isEmpty else {
+      return
+    }
+
+    for url in filteredUrls {
+      try uploadItem(url: url)
+    }
+
+    // Best-effort refresh for Files/MediaStore views on Android 11+.
+    _ = try? ADB.broadcastMediaScan(device: device, path: destinationPath)
+
+    let uploadedLabel: String
+    if filteredUrls.count == 1 {
+      uploadedLabel = filteredUrls[0].lastPathComponent
+    } else {
+      uploadedLabel = "\(filteredUrls.count) items"
+    }
+
+    MiniSim.showSuccessMessage(
+      title: "Upload complete",
+      message: "Uploaded \(uploadedLabel) to \(destinationPath)."
+    )
+  }
+
+  private func uploadItem(url: URL) throws {
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+    guard exists else {
+      return
+    }
+
+    if isDirectory.boolValue {
+      try uploadDirectory(url: url)
+    } else {
+      try ADB.push(device: device, sourcePath: url.path, destinationPath: destinationPath)
+    }
+  }
+
+  private func uploadDirectory(url: URL) throws {
+    let baseRemoteDir = destinationPath + "/" + url.lastPathComponent
+    let rootComponents = url.pathComponents
+    let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
+
+    guard let enumerator = FileManager.default.enumerator(
+      at: url,
+      includingPropertiesForKeys: Array(resourceKeys),
+      options: [],
+      errorHandler: { _, _ in true }
+    ) else {
+      return
+    }
+
+    for case let fileUrl as URL in enumerator {
+      if fileUrl.lastPathComponent == ".DS_Store" {
+        continue
+      }
+
+      let resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
+      guard resourceValues.isRegularFile == true else {
+        continue
+      }
+
+      let fileComponents = fileUrl.pathComponents
+      guard fileComponents.count >= rootComponents.count else {
+        continue
+      }
+
+      let relativeComponents = Array(fileComponents.dropFirst(rootComponents.count))
+      guard !relativeComponents.isEmpty else {
+        continue
+      }
+
+      let relativeDirComponents = Array(relativeComponents.dropLast())
+      let remoteDir = ([baseRemoteDir] + relativeDirComponents).joined(separator: "/")
+
+      try ADB.push(device: device, sourcePath: fileUrl.path, destinationPath: remoteDir)
+    }
+  }
+
+  private func pickUploadItems() -> [URL] {
+    let openPanelAction: () -> [URL] = {
+      let panel = NSOpenPanel()
+      NSApp.activate(ignoringOtherApps: true)
+      panel.allowsMultipleSelection = true
+      panel.canChooseFiles = true
+      panel.canChooseDirectories = true
+      panel.prompt = "Upload"
+      panel.message = "Choose files or folders to upload to \(self.destinationPath)."
+      let response = panel.runModal()
+      return response == .OK ? panel.urls : []
+    }
+
+    if Thread.isMainThread {
+      return openPanelAction()
+    }
+
+    return DispatchQueue.main.sync {
+      openPanelAction()
+    }
+  }
+}
+
 class LaunchLogCat: Action {
   let device: Device
 

--- a/MiniSim/Service/Actions.swift
+++ b/MiniSim/Service/Actions.swift
@@ -122,31 +122,57 @@ class PasteClipboardAction: Action {
 
 class UploadToDownloadsAction: Action {
   let device: Device
-  private let destinationPath = "/sdcard/Download"
+  let destinationLabel = "Downloads"
 
-  init(device: Device) {
+
+    init(device: Device) {
     self.device = device
   }
 
   func execute() throws {
-    let selectedUrls = pickUploadItems()
-    let filteredUrls = selectedUrls.filter { $0.lastPathComponent != ".DS_Store" }
-    guard !filteredUrls.isEmpty else {
+    guard let destinationPath = try resolveDestinationPath() else {
+      NSSound.beep()
+      NSAlert.showError(
+        message: NSLocalizedString(
+            "Downloads folder not found on device. Expected \(AndroidUploadPathBuilder.primaryDestinationPath) or \(AndroidUploadPathBuilder.fallbackDestinationPath).",
+          comment: ""
+        )
+      )
       return
     }
 
-    for url in filteredUrls {
-      try uploadItem(url: url)
+    let selectedUrls = UploadHelpers.pickUploadItems(
+      prompt: "Upload",
+      message: "Choose files or folders to upload to \(destinationLabel)."
+    )
+
+    let result = try UploadHelpers.processUploadItems(
+      selectedUrls: selectedUrls,
+      destinationLabel: destinationLabel,
+      missingItemHandler: UploadHelpers.promptForMissingItem
+    ) { file in
+      let destinationFilePath = AndroidUploadPathBuilder.destinationFilePath(
+        for: file,
+        destinationPath: destinationPath
+      )
+      try ADB.push(device: device, sourcePath: file.sourceURL.path, destinationPath: destinationFilePath)
     }
 
-    // Best-effort refresh for Files/MediaStore views on Android 11+.
+    if result.canceled || result.uploadedCount == 0 {
+      return
+    }
+      
+    // Best-effort folder content refresh for Files/MediaStore views (Files app) on Android 11+.
+    // (use deprecated MediaScanner broadcast to force path reindexing)
+    // See https://stackoverflow.com/questions/66929450/images-not-shown-in-photos-using-adb-push-pictures-to-android-11-emulator
+    // and https://stackoverflow.com/questions/64552886/adb-push-files-are-not-showing-on-android-11-emulator
     _ = try? ADB.broadcastMediaScan(device: device, path: destinationPath)
 
     let uploadedLabel: String
-    if filteredUrls.count == 1 {
-      uploadedLabel = filteredUrls[0].lastPathComponent
+    if result.uploadedCount == 1, let itemName = result.singleUploadedItemName {
+      uploadedLabel = itemName
     } else {
-      uploadedLabel = "\(filteredUrls.count) items"
+      uploadedLabel = "\(result.uploadedCount) items"
     }
 
     MiniSim.showSuccessMessage(
@@ -155,83 +181,17 @@ class UploadToDownloadsAction: Action {
     )
   }
 
-  private func uploadItem(url: URL) throws {
-    var isDirectory: ObjCBool = false
-    let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
-    guard exists else {
-      return
+  private func resolveDestinationPath() throws -> String? {
+    if try ADB.directoryExists(device: device, path: AndroidUploadPathBuilder.primaryDestinationPath) {
+        return AndroidUploadPathBuilder.primaryDestinationPath
     }
-
-    if isDirectory.boolValue {
-      try uploadDirectory(url: url)
-    } else {
-      try ADB.push(device: device, sourcePath: url.path, destinationPath: destinationPath)
+    if try ADB.directoryExists(device: device, path: AndroidUploadPathBuilder.fallbackDestinationPath) {
+        return AndroidUploadPathBuilder.fallbackDestinationPath
     }
-  }
-
-  private func uploadDirectory(url: URL) throws {
-    let baseRemoteDir = destinationPath + "/" + url.lastPathComponent
-    let rootComponents = url.pathComponents
-    let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
-
-    guard let enumerator = FileManager.default.enumerator(
-      at: url,
-      includingPropertiesForKeys: Array(resourceKeys),
-      options: [],
-      errorHandler: { _, _ in true }
-    ) else {
-      return
-    }
-
-    for case let fileUrl as URL in enumerator {
-      if fileUrl.lastPathComponent == ".DS_Store" {
-        continue
-      }
-
-      let resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
-      guard resourceValues.isRegularFile == true else {
-        continue
-      }
-
-      let fileComponents = fileUrl.pathComponents
-      guard fileComponents.count >= rootComponents.count else {
-        continue
-      }
-
-      let relativeComponents = Array(fileComponents.dropFirst(rootComponents.count))
-      guard !relativeComponents.isEmpty else {
-        continue
-      }
-
-      let relativeDirComponents = Array(relativeComponents.dropLast())
-      let remoteDir = ([baseRemoteDir] + relativeDirComponents).joined(separator: "/")
-
-      try ADB.push(device: device, sourcePath: fileUrl.path, destinationPath: remoteDir)
-    }
-  }
-
-  private func pickUploadItems() -> [URL] {
-    let openPanelAction: () -> [URL] = {
-      let panel = NSOpenPanel()
-      NSApp.activate(ignoringOtherApps: true)
-      panel.allowsMultipleSelection = true
-      panel.canChooseFiles = true
-      panel.canChooseDirectories = true
-      panel.prompt = "Upload"
-      panel.message = "Choose files or folders to upload to \(self.destinationPath)."
-      let response = panel.runModal()
-      return response == .OK ? panel.urls : []
-    }
-
-    if Thread.isMainThread {
-      return openPanelAction()
-    }
-
-    return DispatchQueue.main.sync {
-      openPanelAction()
-    }
+    return nil
   }
 }
+
 
 class LaunchLogCat: Action {
   let device: Device
@@ -393,100 +353,57 @@ class UploadToSimulatorFilesAction: Action {
   }
 
   func execute() throws {
-    let selectedUrls = pickUploadItems()
-    let filteredUrls = selectedUrls.filter { $0.lastPathComponent != ".DS_Store" }
-    guard !filteredUrls.isEmpty else {
+    let storageURL = try SimulatorFileProviderStorage.url(for: device)
+
+    let selectedUrls = UploadHelpers.pickUploadItems(
+      prompt: "Upload",
+      message: "Choose files or folders to upload to \(destinationLabel)."
+    )
+
+    let result = try UploadHelpers.processUploadItems(
+      selectedUrls: selectedUrls,
+      destinationLabel: destinationLabel,
+      missingItemHandler: UploadHelpers.promptForMissingItem,
+      directoryStartHandler: { directoryURL in
+        let baseDestination = storageURL.appendingPathComponent(
+          directoryURL.lastPathComponent,
+          isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+          at: baseDestination,
+          withIntermediateDirectories: true,
+          attributes: nil
+        )
+      }
+    ) { file in
+      let destinationDir = destinationDirectory(for: file, baseURL: storageURL)
+      try FileManager.default.createDirectory(
+        at: destinationDir,
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+      let destinationFile = destinationDir.appendingPathComponent(
+        file.sourceURL.lastPathComponent,
+        isDirectory: false
+      )
+      try copyItemReplacingIfNeeded(from: file.sourceURL, to: destinationFile)
+    }
+
+    if result.canceled || result.uploadedCount == 0 {
       return
     }
 
-    let storageURL = try SimulatorFileProviderStorage.url(for: device)
-
-    for url in filteredUrls {
-      try uploadItem(url: url, destinationURL: storageURL)
-    }
-
     let uploadedLabel: String
-    if filteredUrls.count == 1 {
-      uploadedLabel = filteredUrls[0].lastPathComponent
+    if result.uploadedCount == 1, let itemName = result.singleUploadedItemName {
+      uploadedLabel = itemName
     } else {
-      uploadedLabel = "\(filteredUrls.count) items"
+      uploadedLabel = "\(result.uploadedCount) items"
     }
 
     MiniSim.showSuccessMessage(
       title: "Upload complete",
       message: "Uploaded \(uploadedLabel) to \(destinationLabel)."
     )
-  }
-
-  private func uploadItem(url: URL, destinationURL: URL) throws {
-    var isDirectory: ObjCBool = false
-    let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
-    guard exists else {
-      return
-    }
-
-    if isDirectory.boolValue {
-      try uploadDirectory(url: url, destinationURL: destinationURL)
-    } else {
-      let fileDestination = destinationURL.appendingPathComponent(url.lastPathComponent, isDirectory: false)
-      try copyItemReplacingIfNeeded(from: url, to: fileDestination)
-    }
-  }
-
-  private func uploadDirectory(url: URL, destinationURL: URL) throws {
-    let baseDestination = destinationURL.appendingPathComponent(url.lastPathComponent, isDirectory: true)
-    let rootComponents = url.pathComponents
-    let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
-
-    try FileManager.default.createDirectory(
-      at: baseDestination,
-      withIntermediateDirectories: true,
-      attributes: nil
-    )
-
-    guard let enumerator = FileManager.default.enumerator(
-      at: url,
-      includingPropertiesForKeys: Array(resourceKeys),
-      options: [],
-      errorHandler: { _, _ in true }
-    ) else {
-      return
-    }
-
-    for case let fileUrl as URL in enumerator {
-      if fileUrl.lastPathComponent == ".DS_Store" {
-        continue
-      }
-
-      let resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
-      guard resourceValues.isRegularFile == true else {
-        continue
-      }
-
-      let fileComponents = fileUrl.pathComponents
-      guard fileComponents.count >= rootComponents.count else {
-        continue
-      }
-
-      let relativeComponents = Array(fileComponents.dropFirst(rootComponents.count))
-      guard !relativeComponents.isEmpty else {
-        continue
-      }
-
-      let relativeDirComponents = Array(relativeComponents.dropLast())
-      let destinationDir = relativeDirComponents.reduce(baseDestination) { partial, component in
-        partial.appendingPathComponent(component, isDirectory: true)
-      }
-
-      try FileManager.default.createDirectory(
-        at: destinationDir,
-        withIntermediateDirectories: true,
-        attributes: nil
-      )
-
-      let destinationFile = destinationDir.appendingPathComponent(fileUrl.lastPathComponent, isDirectory: false)
-      try copyItemReplacingIfNeeded(from: fileUrl, to: destinationFile)
-    }
   }
 
   private func copyItemReplacingIfNeeded(from sourceURL: URL, to destinationURL: URL) throws {
@@ -496,26 +413,15 @@ class UploadToSimulatorFilesAction: Action {
     try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
   }
 
-  private func pickUploadItems() -> [URL] {
-    let openPanelAction: () -> [URL] = {
-      let panel = NSOpenPanel()
-      NSApp.activate(ignoringOtherApps: true)
-      panel.allowsMultipleSelection = true
-      panel.canChooseFiles = true
-      panel.canChooseDirectories = true
-      panel.prompt = "Upload"
-      panel.message = "Choose files or folders to upload to \(self.destinationLabel)."
-      let response = panel.runModal()
-      return response == .OK ? panel.urls : []
+  private func destinationDirectory(for file: UploadFileReference, baseURL: URL) -> URL {
+    var destinationDir = baseURL
+    if let rootDirectoryName = file.rootDirectoryName {
+      destinationDir = destinationDir.appendingPathComponent(rootDirectoryName, isDirectory: true)
     }
-
-    if Thread.isMainThread {
-      return openPanelAction()
+    for component in file.relativeDirectoryComponents {
+      destinationDir = destinationDir.appendingPathComponent(component, isDirectory: true)
     }
-
-    return DispatchQueue.main.sync {
-      openPanelAction()
-    }
+    return destinationDir
   }
 }
 

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -23,6 +23,7 @@ protocol ADBProtocol {
   static func sendText(device: Device, text: String) throws
   static func push(device: Device, sourcePath: String, destinationPath: String) throws
   static func broadcastMediaScan(device: Device, path: String) throws
+  static func directoryExists(device: Device, path: String) throws -> Bool
   static func launchLogCat(device: Device) throws
 }
 
@@ -157,9 +158,12 @@ final class ADB: ADBProtocol {
       throw DeviceError.deviceNotFound
     }
 
+    let destinationDir = (destinationPath as NSString).deletingLastPathComponent
+    let quotedDestinationDir = adbShellQuote(destinationDir)
+
     try shell.execute(
       command: adbPath,
-      arguments: ["-s", deviceId, "shell", "mkdir", "-p", destinationPath]
+      arguments: ["-s", deviceId, "shell", "mkdir", "-p", quotedDestinationDir]
     )
     try shell.execute(
       command: adbPath,
@@ -174,6 +178,7 @@ final class ADB: ADBProtocol {
     }
 
     let fileUri = "file://\(path)"
+    let quotedFileUri = adbShellQuote(fileUri)
     try shell.execute(
       command: adbPath,
       arguments: [
@@ -186,9 +191,26 @@ final class ADB: ADBProtocol {
         "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
         "--receiver-include-background",
         "-d",
-        fileUri
+        quotedFileUri
       ]
     )
+  }
+
+  static func directoryExists(device: Device, path: String) throws -> Bool {
+    let adbPath = try ADB.getAdbPath()
+    guard let deviceId = device.identifier else {
+      throw DeviceError.deviceNotFound
+    }
+
+    do {
+      try shell.execute(
+        command: adbPath,
+        arguments: ["-s", deviceId, "shell", "test", "-d", adbShellQuote(path)]
+      )
+      return true
+    } catch {
+      return false
+    }
   }
 
   static func launchLogCat(device: Device) throws {
@@ -200,4 +222,12 @@ final class ADB: ADBProtocol {
     let logcatCommand = "\(adbPath) -s \(deviceId) logcat -v color"
     try TerminalService.launchTerminal(command: logcatCommand)
   }
+
+  private static func adbShellQuote(_ value: String) -> String {
+    let escaped = value
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+    return "\"\(escaped)\""
+  }
+
 }

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -21,6 +21,8 @@ protocol ADBProtocol {
   static func isAccesibilityOn(deviceId: String) -> Bool
   static func toggleAccesibility(deviceId: String)
   static func sendText(device: Device, text: String) throws
+  static func push(device: Device, sourcePath: String, destinationPath: String) throws
+  static func broadcastMediaScan(device: Device, path: String) throws
   static func launchLogCat(device: Device) throws
 }
 
@@ -147,6 +149,46 @@ final class ADB: ADBProtocol {
     let formattedText = text.replacingOccurrences(of: " ", with: "%s").replacingOccurrences(of: "'", with: "''")
 
     try shell.execute(command: "\(adbPath) -s \(deviceId) shell input text \"\(formattedText)\"")
+  }
+
+  static func push(device: Device, sourcePath: String, destinationPath: String) throws {
+    let adbPath = try ADB.getAdbPath()
+    guard let deviceId = device.identifier else {
+      throw DeviceError.deviceNotFound
+    }
+
+    try shell.execute(
+      command: adbPath,
+      arguments: ["-s", deviceId, "shell", "mkdir", "-p", destinationPath]
+    )
+    try shell.execute(
+      command: adbPath,
+      arguments: ["-s", deviceId, "push", sourcePath, destinationPath]
+    )
+  }
+
+  static func broadcastMediaScan(device: Device, path: String) throws {
+    let adbPath = try ADB.getAdbPath()
+    guard let deviceId = device.identifier else {
+      throw DeviceError.deviceNotFound
+    }
+
+    let fileUri = "file://\(path)"
+    try shell.execute(
+      command: adbPath,
+      arguments: [
+        "-s",
+        deviceId,
+        "shell",
+        "am",
+        "broadcast",
+        "-a",
+        "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+        "--receiver-include-background",
+        "-d",
+        fileUri
+      ]
+    )
   }
 
   static func launchLogCat(device: Device) throws {

--- a/MiniSim/Service/Shell.swift
+++ b/MiniSim/Service/Shell.swift
@@ -20,14 +20,29 @@ extension ShellProtocol {
 }
 
 final class Shell: ShellProtocol {
+    static func escapeShellArgument(_ argument: String) -> String {
+        if argument.isEmpty {
+            return "''"
+        }
+        let escaped = argument.replacingOccurrences(of: "'", with: "'\"'\"'")
+        return "'\(escaped)'"
+    }
+
     @discardableResult func execute(
         command: String,
         arguments: [String] = [],
         atPath: String = "."
     ) throws -> String {
-        try shellOut(
-            to: command,
-            arguments: arguments,
+        let commandWithArguments: String
+        if arguments.isEmpty {
+            commandWithArguments = command
+        } else {
+            let escapedArguments = arguments.map(Self.escapeShellArgument).joined(separator: " ")
+            commandWithArguments = "\(command) \(escapedArguments)"
+        }
+
+        return try shellOut(
+            to: commandWithArguments,
             at: atPath
         )
     }

--- a/MiniSim/Service/UploadHelpers.swift
+++ b/MiniSim/Service/UploadHelpers.swift
@@ -1,0 +1,272 @@
+import AppKit
+import Foundation
+import OSLog
+
+enum UploadMissingScope {
+  case singleSelection
+  case multipleSelection
+  case directoryContents
+}
+
+
+enum UploadMissingDecision {
+  case cancel
+  case ignore
+}
+
+
+struct UploadMissingContext {
+  let url: URL
+  let scope: UploadMissingScope
+  let destinationLabel: String
+}
+
+
+struct UploadFileReference {
+  let sourceURL: URL
+  let rootDirectoryName: String?
+  let relativeDirectoryComponents: [String]
+}
+
+
+struct UploadProcessingResult {
+  let uploadedCount: Int
+  let singleUploadedItemName: String?
+  let canceled: Bool
+}
+
+
+struct AndroidUploadPathBuilder {
+  // Some manufacturers have different naming of internal-storage /sdcard/Download folder
+  static let primaryDestinationPath = "/sdcard/Download"
+  static let fallbackDestinationPath = "/sdcard/Downloads"
+    
+  static func destinationFilePath(for file: UploadFileReference, destinationPath: String) -> String {
+    let remoteDir = remoteDirectory(for: file, destinationPath: destinationPath)
+    return remoteDir + "/" + file.sourceURL.lastPathComponent
+  }
+
+  static func remoteDirectory(for file: UploadFileReference, destinationPath: String) -> String {
+    var components = [destinationPath]
+    if let rootDirectoryName = file.rootDirectoryName {
+      components.append(rootDirectoryName)
+    }
+    if !file.relativeDirectoryComponents.isEmpty {
+      components.append(contentsOf: file.relativeDirectoryComponents)
+    }
+    return components.joined(separator: "/")
+  }
+}
+
+
+struct UploadHelpers {
+  private static let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "MiniSim",
+    category: "Upload"
+  )
+
+  static func pickUploadItems(prompt: String, message: String) -> [URL] {
+    let openPanelAction: () -> [URL] = {
+      let panel = NSOpenPanel()
+      NSApp.activate(ignoringOtherApps: true)
+      panel.allowsMultipleSelection = true
+      panel.canChooseFiles = true
+      panel.canChooseDirectories = true
+      panel.prompt = prompt
+      panel.message = message
+      let response = panel.runModal()
+      return response == .OK ? panel.urls : []
+    }
+
+    if Thread.isMainThread {
+      return openPanelAction()
+    }
+
+    return DispatchQueue.main.sync {
+      openPanelAction()
+    }
+  }
+
+  static func processUploadItems(
+    selectedUrls: [URL],
+    destinationLabel: String,
+    missingItemHandler: (UploadMissingContext) -> UploadMissingDecision = UploadHelpers.promptForMissingItem,
+    directoryStartHandler: ((URL) throws -> Void)? = nil,
+    fileHandler: (UploadFileReference) throws -> Void
+  ) throws -> UploadProcessingResult {
+    let filteredUrls = selectedUrls.filter { $0.lastPathComponent != ".DS_Store" }
+    guard !filteredUrls.isEmpty else {
+      return UploadProcessingResult(uploadedCount: 0, singleUploadedItemName: nil, canceled: false)
+    }
+
+    let isSingleSelection = filteredUrls.count == 1
+    var uploadedCount = 0
+    var singleUploadedItemName: String?
+    var missingDecision: UploadMissingDecision?
+
+    func shouldContinueAfterMissing(url: URL, scope: UploadMissingScope) -> Bool {
+      logger.warning("Upload source missing: \(url.path, privacy: .public)")
+      if let decision = missingDecision {
+        return decision == .ignore
+      }
+
+      let decision = missingItemHandler(
+        UploadMissingContext(url: url, scope: scope, destinationLabel: destinationLabel)
+      )
+      if decision == .ignore && scope != .singleSelection {
+        missingDecision = .ignore
+      }
+      return decision == .ignore
+    }
+
+    func handleFile(_ file: UploadFileReference) throws {
+      try fileHandler(file)
+      uploadedCount += 1
+      if uploadedCount == 1 {
+        singleUploadedItemName = file.sourceURL.lastPathComponent
+      } else {
+        singleUploadedItemName = nil
+      }
+    }
+
+    for url in filteredUrls {
+      var isDirectory: ObjCBool = false
+      let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+      guard exists else {
+        let scope: UploadMissingScope = isSingleSelection ? .singleSelection : .multipleSelection
+        if !shouldContinueAfterMissing(url: url, scope: scope) {
+          return UploadProcessingResult(
+            uploadedCount: uploadedCount,
+            singleUploadedItemName: singleUploadedItemName,
+            canceled: true
+          )
+        }
+        continue
+      }
+
+      if isDirectory.boolValue {
+        try directoryStartHandler?(url)
+        let canceled = try processDirectory(
+          directoryURL: url,
+          shouldContinueAfterMissing: shouldContinueAfterMissing,
+          fileHandler: handleFile
+        )
+        if canceled {
+          return UploadProcessingResult(
+            uploadedCount: uploadedCount,
+            singleUploadedItemName: singleUploadedItemName,
+            canceled: true
+          )
+        }
+      } else {
+        try handleFile(
+          UploadFileReference(
+            sourceURL: url,
+            rootDirectoryName: nil,
+            relativeDirectoryComponents: []
+          )
+        )
+      }
+    }
+
+    return UploadProcessingResult(
+      uploadedCount: uploadedCount,
+      singleUploadedItemName: singleUploadedItemName,
+      canceled: false
+    )
+  }
+
+  static func promptForMissingItem(_ context: UploadMissingContext) -> UploadMissingDecision {
+    let title = "File not found"
+    let path = context.url.path
+
+    switch context.scope {
+    case .singleSelection:
+      let message = "Selected item could not be found:\n\(path)\nUpload canceled."
+      _ = NSAlert.showWarningDialog(
+        title: title,
+        message: message,
+        primaryButton: "Cancel",
+        secondaryButton: nil
+      )
+      return .cancel
+    case .multipleSelection, .directoryContents:
+      let message = "Missing item while uploading to \(context.destinationLabel):\n\(path)\nIgnore and Continue will skip this item."
+      let response = NSAlert.showWarningDialog(
+        title: title,
+        message: message,
+        primaryButton: "Cancel",
+        secondaryButton: "Ignore and Continue"
+      )
+      return response == .alertSecondButtonReturn ? .ignore : .cancel
+    }
+  }
+
+  private static func processDirectory(
+    directoryURL: URL,
+    shouldContinueAfterMissing: (URL, UploadMissingScope) -> Bool,
+    fileHandler: (UploadFileReference) throws -> Void
+  ) throws -> Bool {
+    let rootDirectoryName = directoryURL.lastPathComponent
+    let rootPath = directoryURL.standardizedFileURL.path
+    let rootPathWithSlash = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+    let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
+
+    guard let enumerator = FileManager.default.enumerator(
+      at: directoryURL,
+      includingPropertiesForKeys: Array(resourceKeys),
+      options: [],
+      errorHandler: { url, error in
+        logger.error(
+          "Upload enumeration error at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+        return true
+      }
+    ) else {
+      logger.warning("Upload directory enumerator missing for \(directoryURL.path, privacy: .public)")
+      return false
+    }
+
+    for case let fileUrl as URL in enumerator {
+      if fileUrl.lastPathComponent == ".DS_Store" {
+        continue
+      }
+
+      let resourceValues: URLResourceValues
+      do {
+        resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
+      } catch {
+        logger.warning(
+          "Upload source missing or unreadable: \(fileUrl.path, privacy: .public) error: \(error.localizedDescription, privacy: .public)"
+        )
+        if !shouldContinueAfterMissing(fileUrl, .directoryContents) {
+          return true
+        }
+        continue
+      }
+
+      guard resourceValues.isRegularFile == true else {
+        continue
+      }
+
+      let filePath = fileUrl.standardizedFileURL.path
+      guard filePath.hasPrefix(rootPathWithSlash) else {
+        continue
+      }
+      let relativePath = String(filePath.dropFirst(rootPathWithSlash.count))
+      let relativeComponents = relativePath.split(separator: "/").map(String.init)
+      guard !relativeComponents.isEmpty else { continue }
+      let relativeDirComponents = Array(relativeComponents.dropLast())
+
+      try fileHandler(
+        UploadFileReference(
+          sourceURL: fileUrl,
+          rootDirectoryName: rootDirectoryName,
+          relativeDirectoryComponents: relativeDirComponents
+        )
+      )
+    }
+
+    return false
+  }
+}

--- a/MiniSimTests/ADBTests.swift
+++ b/MiniSimTests/ADBTests.swift
@@ -129,4 +129,35 @@ final class ADBTests: XCTestCase {
     XCTAssertEqual(shellStub.lastExecutedCommand, expectedCommand)
     XCTAssertEqual(shellStub.lastPassedArguments, [])
   }
+
+  func testPushWithSpacesPassesFullArguments() throws {
+    var calls: [(command: String, arguments: [String], path: String)] = []
+    shellStub.mockedExecute = { command, arguments, path in
+      calls.append((command: command, arguments: arguments, path: path))
+      return ""
+    }
+
+    let device = Device(
+      name: "Pixel",
+      version: "14",
+      identifier: "emulator-5554",
+      booted: true,
+      platform: .android,
+      type: .virtual
+    )
+    let sourcePath = "/Users/jki/Downloads/ai assistants.jpg"
+    let destinationPath = "/sdcard/Download/backup mahdi/ai assistants.jpg"
+
+    try ADB.push(device: device, sourcePath: sourcePath, destinationPath: destinationPath)
+
+    XCTAssertEqual(calls.count, 2)
+    XCTAssertEqual(
+      calls[0].arguments,
+      ["-s", "emulator-5554", "shell", "mkdir", "-p", "\"/sdcard/Download/backup mahdi\""]
+    )
+    XCTAssertEqual(
+      calls[1].arguments,
+      ["-s", "emulator-5554", "push", sourcePath, destinationPath]
+    )
+  }
 }

--- a/MiniSimTests/ActionFactoryTests.swift
+++ b/MiniSimTests/ActionFactoryTests.swift
@@ -39,6 +39,8 @@ class ActionFactoryTests: XCTestCase {
         XCTAssertTrue(action is PasteClipboardAction)
       case .upload:
         XCTAssertTrue(action is UploadToDownloadsAction)
+      case .localFiles:
+        XCTAssertTrue(action is UnsupportedAction)
       case .delete:
         XCTAssertTrue(action is DeleteAction)
       case .customCommand:
@@ -53,7 +55,7 @@ class ActionFactoryTests: XCTestCase {
     let device = Device(name: "Test iOS Device", identifier: "test_id", platform: .ios, type: .physical)
 
     for tag in SubMenuItems.Tags.allCases {
-      if tag == .noAudio || tag == .toggleA11y || tag == .paste || tag == .upload || tag == .logcat {
+      if tag == .noAudio || tag == .toggleA11y || tag == .paste || tag == .logcat {
         // These actions are not supported for iOS, so we skip them
         continue
       }
@@ -70,6 +72,10 @@ class ActionFactoryTests: XCTestCase {
         XCTAssertTrue(action is ColdBootCommand)
       case .delete:
         XCTAssertTrue(action is DeleteAction)
+      case .upload:
+        XCTAssertTrue(action is UploadToSimulatorFilesAction)
+      case .localFiles:
+        XCTAssertTrue(action is OpenSimulatorFilesAction)
       case .customCommand:
         XCTAssertTrue(action is CustomCommandAction)
       default:

--- a/MiniSimTests/ActionFactoryTests.swift
+++ b/MiniSimTests/ActionFactoryTests.swift
@@ -37,6 +37,8 @@ class ActionFactoryTests: XCTestCase {
         XCTAssertTrue(action is ToggleA11yCommand)
       case .paste:
         XCTAssertTrue(action is PasteClipboardAction)
+      case .upload:
+        XCTAssertTrue(action is UploadToDownloadsAction)
       case .delete:
         XCTAssertTrue(action is DeleteAction)
       case .customCommand:
@@ -51,7 +53,7 @@ class ActionFactoryTests: XCTestCase {
     let device = Device(name: "Test iOS Device", identifier: "test_id", platform: .ios, type: .physical)
 
     for tag in SubMenuItems.Tags.allCases {
-      if tag == .noAudio || tag == .toggleA11y || tag == .paste || tag == .logcat {
+      if tag == .noAudio || tag == .toggleA11y || tag == .paste || tag == .upload || tag == .logcat {
         // These actions are not supported for iOS, so we skip them
         continue
       }

--- a/MiniSimTests/CustomCommandServiceTests.swift
+++ b/MiniSimTests/CustomCommandServiceTests.swift
@@ -11,6 +11,10 @@ class CustomCommandServiceTests: XCTestCase {
 
     static func broadcastMediaScan(device: Device, path: String) throws {}
 
+    static func directoryExists(device: Device, path: String) throws -> Bool {
+      false
+    }
+
     static func launchLogCat(device: Device) throws {}
 
     static func getAndroidHome() throws -> String {

--- a/MiniSimTests/CustomCommandServiceTests.swift
+++ b/MiniSimTests/CustomCommandServiceTests.swift
@@ -7,6 +7,10 @@ class CustomCommandServiceTests: XCTestCase {
 
     static func sendText(device: Device, text: String) throws {}
 
+    static func push(device: Device, sourcePath: String, destinationPath: String) throws {}
+
+    static func broadcastMediaScan(device: Device, path: String) throws {}
+
     static func launchLogCat(device: Device) throws {}
 
     static func getAndroidHome() throws -> String {

--- a/MiniSimTests/DeviceParserTests.swift
+++ b/MiniSimTests/DeviceParserTests.swift
@@ -7,6 +7,12 @@ class DeviceParserTests: XCTestCase {
     static func sendText(device: Device, text: String) throws {
     }
 
+    static func push(device: Device, sourcePath: String, destinationPath: String) throws {
+    }
+
+    static func broadcastMediaScan(device: Device, path: String) throws {
+    }
+
     static func launchLogCat(device: Device) throws {
     }
 
@@ -333,6 +339,12 @@ class DeviceParserTests: XCTestCase {
   func testAndroidEmulatorParserWithADBFailure() {
     class FailingADB: ADBProtocol {
       static func sendText(device: Device, text: String) throws {
+      }
+
+      static func push(device: Device, sourcePath: String, destinationPath: String) throws {
+      }
+
+      static func broadcastMediaScan(device: Device, path: String) throws {
       }
 
       static func launchLogCat(device: Device) throws {

--- a/MiniSimTests/DeviceParserTests.swift
+++ b/MiniSimTests/DeviceParserTests.swift
@@ -13,6 +13,10 @@ class DeviceParserTests: XCTestCase {
     static func broadcastMediaScan(device: Device, path: String) throws {
     }
 
+    static func directoryExists(device: Device, path: String) throws -> Bool {
+      false
+    }
+
     static func launchLogCat(device: Device) throws {
     }
 
@@ -345,6 +349,10 @@ class DeviceParserTests: XCTestCase {
       }
 
       static func broadcastMediaScan(device: Device, path: String) throws {
+      }
+
+      static func directoryExists(device: Device, path: String) throws -> Bool {
+        false
       }
 
       static func launchLogCat(device: Device) throws {

--- a/MiniSimTests/ShellEscapingTests.swift
+++ b/MiniSimTests/ShellEscapingTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import MiniSim
+
+final class ShellEscapingTests: XCTestCase {
+  func testEscapeShellArgumentWithSpaces() {
+    let escaped = Shell.escapeShellArgument("ai assistants.jpg")
+    XCTAssertEqual(escaped, "'ai assistants.jpg'")
+  }
+
+  func testEscapeShellArgumentWithSingleQuote() {
+    let escaped = Shell.escapeShellArgument("mahdi's backup")
+    XCTAssertEqual(escaped, "'mahdi'\"'\"'s backup'")
+  }
+}

--- a/MiniSimTests/UploadHelpersTests.swift
+++ b/MiniSimTests/UploadHelpersTests.swift
@@ -1,0 +1,108 @@
+@testable import MiniSim
+import XCTest
+
+class UploadHelpersTests: XCTestCase {
+  private func makeTempDirectory() throws -> URL {
+    let baseURL = FileManager.default.temporaryDirectory
+    let directoryURL = baseURL.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
+    return directoryURL
+  }
+
+  func testProcessUploadItemsSingleMissingCancels() throws {
+    let tempDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let missingURL = tempDir.appendingPathComponent("missing.txt")
+    var contexts: [UploadMissingContext] = []
+
+    let result = try UploadHelpers.processUploadItems(
+      selectedUrls: [missingURL],
+      destinationLabel: "Downloads",
+      missingItemHandler: { context in
+        contexts.append(context)
+        return .cancel
+      },
+      fileHandler: { _ in
+        XCTFail("fileHandler should not be called for missing file")
+      }
+    )
+
+    XCTAssertTrue(result.canceled)
+    XCTAssertEqual(result.uploadedCount, 0)
+    XCTAssertEqual(contexts.count, 1)
+    XCTAssertEqual(contexts.first?.scope, .singleSelection)
+  }
+
+  func testProcessUploadItemsMultipleMissingIgnoreContinues() throws {
+    let tempDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let existingURL = tempDir.appendingPathComponent("exists.txt")
+    try Data("ok".utf8).write(to: existingURL)
+
+    let missingURL = tempDir.appendingPathComponent("missing.txt")
+    var contexts: [UploadMissingContext] = []
+    var handledFiles: [URL] = []
+
+    let result = try UploadHelpers.processUploadItems(
+      selectedUrls: [missingURL, existingURL],
+      destinationLabel: "Downloads",
+      missingItemHandler: { context in
+        contexts.append(context)
+        return .ignore
+      },
+      fileHandler: { file in
+        handledFiles.append(file.sourceURL)
+      }
+    )
+
+    XCTAssertFalse(result.canceled)
+    XCTAssertEqual(result.uploadedCount, 1)
+    XCTAssertEqual(handledFiles, [existingURL])
+    XCTAssertEqual(contexts.first?.scope, .multipleSelection)
+  }
+
+  func testProcessUploadItemsDirectoryReportsRelativeComponents() throws {
+    let tempDir = try makeTempDirectory()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let rootDir = tempDir.appendingPathComponent("Root", isDirectory: true)
+    let subDir = rootDir.appendingPathComponent("Sub", isDirectory: true)
+    try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true, attributes: nil)
+
+    let fileURL = subDir.appendingPathComponent("file.txt")
+    try Data("data".utf8).write(to: fileURL)
+
+    var capturedFile: UploadFileReference?
+
+    let result = try UploadHelpers.processUploadItems(
+      selectedUrls: [rootDir],
+      destinationLabel: "Local Files",
+      missingItemHandler: { _ in .ignore },
+      fileHandler: { file in
+        capturedFile = file
+      }
+    )
+
+    XCTAssertFalse(result.canceled)
+    XCTAssertEqual(result.uploadedCount, 1)
+    XCTAssertEqual(capturedFile?.rootDirectoryName, "Root")
+    XCTAssertEqual(capturedFile?.relativeDirectoryComponents, ["Sub"])
+  }
+
+  func testAndroidUploadPathBuilderPreservesSpaces() {
+    let file = UploadFileReference(
+      sourceURL: URL(fileURLWithPath: "/tmp/ai assistants.jpg"),
+      rootDirectoryName: "My Folder",
+      relativeDirectoryComponents: ["Sub Folder"]
+    )
+
+    let destination = AndroidUploadPathBuilder.destinationFilePath(
+      for: file,
+      destinationPath: "/sdcard/Download"
+    )
+
+    XCTAssertEqual(destination, "/sdcard/Download/My Folder/Sub Folder/ai assistants.jpg")
+  }
+}


### PR DESCRIPTION
## Summary:

To make it easier to share files from Mac to simulator/emulator environments and physical devices, I have added [Local files] submenu section to iOS emulator, Android emulator and Android device menus with the [Upload...] action that allows you to select file or folder from Mac and upload it to simulator/emulator/device local storage. For Android emulator/device uploaded file/folder will land in the /Downloads folder. On iOS simulator uploaded file/folder will land in device's File Provider Local Storage container. 

In addition added also [Open in Finder...] option that opens simulator's File Provider Local Storage container to make it even easier to copy/paste/share/remove files/folders from the iOS simulator local storage

## Changelog:

Added [Local Files] submenu section with [Upload...] submenu to upload file/folder to simulator/emulator/device. Added extra [Open in Finder...] action to iOS simulator. Moved [Delete] action as last in the device menu.

## Test Plan:

Runned tests. Tested with Mac OS Sequoia 15.7.3, iOS 18.6/iOS 26.2 simulators, Android 16 emulator, Android 16 device. 

<img width="900" height="634" alt="minisim-android-phone" src="https://github.com/user-attachments/assets/21a634e9-dbfd-470c-9b05-25e2dbf49dd3" />
<img width="778" height="586" alt="minisim-ios-sim" src="https://github.com/user-attachments/assets/f7b5bc0e-d4a5-4d83-b2d9-d0edab00911f" />
<img width="896" height="816" alt="minisim-android-emu" src="https://github.com/user-attachments/assets/e5caffef-7f36-4675-8e97-c1aa9ace8a61" />
