### PR TITLE
feat: add Check for Updates button to main menu (closes #97)

### DIFF
--- a/MiniSim/MenuItems/MainMenuActions.swift
+++ b/MiniSim/MenuItems/MainMenuActions.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum MainMenuActions: Int, CaseIterable {
     case clearDerrivedData = 200
+    case checkForUpdates
     case preferences
     case quit
 
@@ -31,6 +32,8 @@ enum MainMenuActions: Int, CaseIterable {
             return NSLocalizedString("Preferences", comment: "")
         case .clearDerrivedData:
             return NSLocalizedString("Clear Xcode Derived Data", comment: "")
+        case .checkForUpdates:
+            return NSLocalizedString("Check for Updates…", comment: "")
         }
     }
 }

--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -7,11 +7,17 @@
 
 import AppKit
 import Settings
+import Sparkle
 import SwiftUI
 import UserNotifications
 
 class MiniSim: NSObject {
     private var menu: Menu!
+    private let updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: nil
+    )
 
     @objc let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
@@ -162,6 +168,8 @@ class MiniSim: NSObject {
                 settingsController.window?.orderFrontRegardless()
             case .quit:
                 NSApp.terminate(sender)
+            case .checkForUpdates:
+                updaterController.updater.checkForUpdates()
             case .clearDerrivedData:
                 let shouldDelete = NSAlert.showQuestionDialog(
                     title: "Are you sure?",


### PR DESCRIPTION
## Summary

Closes #97 — adds a **Check for Updates…** item to the main menu bar dropdown.

### Changes

- **MainMenuActions.swift**: Added `checkForUpdates` case, positioned between `clearDerrivedData` and `preferences`
- **MiniSim.swift**: Added `SPUStandardUpdaterController` instance and handles the new `.checkForUpdates` case in `menuItemAction()`

### How it works

Uses the existing Sparkle framework that was already integrated in the About view. The `SPUStandardUpdaterController` is initialized once in `MiniSim` and triggers `checkForUpdates()` when the menu item is clicked.

### Before/After

**Before**: Users had to open Preferences → About to check for updates  
**After**: "Check for Updates…" is available directly in the menu bar dropdown