### PR TITLE
fix: restore default Android SDK discovery

### DIFF
--- a/MiniSim/MiniSim.swift
+++ b/MiniSim/MiniSim.swift
@@ -80,6 +80,11 @@ class MiniSim: NSObject {
             onboarding.show()
             return
         }
+
+        if UserDefaults.standard.enableAndroidEmulators {
+            _ = try? ADB.configureDefaultAndroidHomeIfNeeded()
+        }
+
         menu = Menu()
         statusItem.menu = menu
         setMenuImage()

--- a/MiniSim/Service/Adb.swift
+++ b/MiniSim/Service/Adb.swift
@@ -57,6 +57,22 @@ final class ADB: ADBProtocol {
     return path + Paths.home.rawValue
   }
 
+  /**
+   Persists the default Android SDK path when a valid SDK exists and no path was saved during onboarding.
+   */
+  @discardableResult static func configureDefaultAndroidHomeIfNeeded(
+    fileManager: FileManager = .default
+  ) throws -> Bool {
+    guard UserDefaults.standard.androidHome == nil else {
+      return false
+    }
+
+    let androidHome = try getAndroidHome()
+    try checkAndroidHome(path: androidHome, fileManager: fileManager)
+    UserDefaults.standard.androidHome = androidHome
+    return true
+  }
+
   static func getAdbPath() throws -> String {
     try getAndroidHome() + Paths.adb.rawValue
   }

--- a/MiniSimTests/ADBTests.swift
+++ b/MiniSimTests/ADBTests.swift
@@ -48,6 +48,31 @@ final class ADBTests: XCTestCase {
     )
   }
 
+  func testConfigureDefaultAndroidHomeIfNeeded() throws {
+    XCTAssertTrue(
+      try ADB.configureDefaultAndroidHomeIfNeeded(fileManager: FileManagerStub())
+    )
+    XCTAssertEqual(UserDefaults.standard.androidHome, defaultHomePath)
+    XCTAssertEqual(shellStub.lastExecutedCommand, defaultHomePath + "/emulator/emulator")
+    XCTAssertEqual(shellStub.lastPassedArguments, ["-list-avds"])
+  }
+
+  func testConfigureDefaultAndroidHomeIfNeededDoesNotOverrideSavedPath() throws {
+    UserDefaults.standard.androidHome = "customAndroidHome"
+
+    XCTAssertFalse(
+      try ADB.configureDefaultAndroidHomeIfNeeded(fileManager: FileManagerStub())
+    )
+    XCTAssertEqual(UserDefaults.standard.androidHome, "customAndroidHome")
+  }
+
+  func testConfigureDefaultAndroidHomeIfNeededRequiresValidSDK() {
+    XCTAssertThrowsError(
+      try ADB.configureDefaultAndroidHomeIfNeeded(fileManager: FileManagerEmptyStub())
+    )
+    XCTAssertNil(UserDefaults.standard.androidHome)
+  }
+
   func testCheckAndroidHome() throws {
     let output = try ADB.checkAndroidHome(
       path: defaultHomePath,


### PR DESCRIPTION
Thank you for building and maintaining this awesome tool! I ran into an issue where Android emulators were not appearing, so I investigated the onboarding and startup flow and put together this fix.

## Summary:

MiniSim can complete onboarding with Android emulators enabled even when Android setup validation fails. The validation error is suppressed, so `isOnboardingFinished` can become `true` while `androidHome` remains unset.

After onboarding, the menu requests Android devices only when `androidHome` is already present in UserDefaults. That guard prevents `ADB.getAndroidHome()` from resolving the default `~/Library/Android/sdk` location, so installing the SDK later does not restore Android emulator discovery automatically.

This change repairs that state before the menu is created:

- when Android emulators are enabled and no SDK path is saved, resolve and validate the default SDK path
- persist the path only when the existing emulator CLI can use it
- preserve an existing custom SDK path
- leave the preference unset when Android is disabled or no valid SDK is available

Performing this repair at startup is intentional. Fixing onboarding alone would not recover users who already completed it with a missing preference or who install the Android SDK later.

This PR does not change the onboarding validation UI or migrate from the legacy `emulator` executable to the new Android CLI. Those can be handled separately.

Refs #149

## Changelog:

Restore Android emulator discovery when onboarding completed without saving the default Android SDK path.

## Test Plan:

- Added unit coverage for persisting a valid default SDK path, preserving a custom path, and rejecting an invalid SDK path.
- Ran the full test suite successfully; the existing iOS device discovery test remained skipped.

- Installed and launched the PR build from `/Applications` and verified these onboarding flows:
  - with a valid Android SDK, onboarding saved the default SDK path and completed normally
  - with Android enabled and the emulator executable temporarily unavailable, onboarding completed with `isOnboardingFinished = true` and no saved `androidHome`; Android menu entries were absent
  - after restoring the emulator executable and relaunching MiniSim, the default SDK path was persisted and the existing Android virtual device appeared in the menu
  - with Android disabled and no usable emulator executable, onboarding completed without saving `androidHome`, and Android menu entries remained absent
