### PR TITLE
fix: keep menu available when device discovery fails

### DIFF
--- a/MiniSim/Service/DeviceDiscoveryService.swift
+++ b/MiniSim/Service/DeviceDiscoveryService.swift
@@ -91,6 +91,14 @@ class IOSDeviceDiscovery: DeviceDiscoveryService {
   }
 
   func checkSetup() throws -> Bool {
-    FileManager.default.fileExists(atPath: DeviceConstants.ProcessPaths.xcrun.rawValue)
+    guard FileManager.default.fileExists(atPath: DeviceConstants.ProcessPaths.xcrun.rawValue) else {
+      return false
+    }
+
+    _ = try shell.execute(
+      command: DeviceConstants.ProcessPaths.xcrun.rawValue,
+      arguments: ["simctl", "list", "devices", "available", "-j"]
+    )
+    return true
   }
 }

--- a/MiniSim/Service/DeviceServiceFactory.swift
+++ b/MiniSim/Service/DeviceServiceFactory.swift
@@ -36,11 +36,19 @@ class DeviceServiceFactory {
         var devicesArray: [Device] = []
 
         if android {
-          try devicesArray.append(contentsOf: AndroidDeviceDiscovery().getDevices())
+          do {
+            try devicesArray.append(contentsOf: AndroidDeviceDiscovery().getDevices())
+          } catch {
+            // A broken Android installation must not prevent the iOS menu from opening.
+          }
         }
 
         if iOS {
-          try devicesArray.append(contentsOf: IOSDeviceDiscovery().getDevices())
+          do {
+            try devicesArray.append(contentsOf: IOSDeviceDiscovery().getDevices())
+          } catch {
+            // xcrun/simctl may be unavailable while the rest of MiniSim is usable.
+          }
         }
 
         completionQueue.async {


### PR DESCRIPTION
## Summary:

Opening MiniSim can fail when `xcrun simctl` is unavailable. The failure is surfaced as a ShellOut error and prevents the menu from opening.

This change keeps MiniSim usable when device discovery for one platform fails, and makes the iOS setup check validate the actual `simctl` command instead of only checking whether `/usr/bin/xcrun` exists.

## Changelog:

- Prevent Android or iOS device discovery errors from blocking the entire MiniSim menu.
- Validate `xcrun simctl` during iOS setup checks.

## Test Plan:

- `xcodebuild -scheme MiniSim -configuration Debug -sdk macosx -derivedDataPath /tmp/minisim-derived -clonedSourcePackagesDirPath /tmp/minisim-packages build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -scheme MiniSim -destination 'platform=macOS' -derivedDataPath /tmp/minisim-derived -clonedSourcePackagesDirPath /tmp/minisim-packages CODE_SIGNING_ALLOWED=NO`
- `git diff --check`

All tests passed.

Manual reproduction is environment-dependent because it requires an unavailable or misconfigured Xcode `simctl` installation. The reported failure is documented in #150.
